### PR TITLE
✨ Feat: View들간 화면 연결

### DIFF
--- a/Bragit/App/Flow/AppStep.swift
+++ b/Bragit/App/Flow/AppStep.swift
@@ -35,6 +35,8 @@ enum AppStep: Step {
   case feedDetail(post: Post)          // 피드 상세
   case comment(id: UUID)               // 댓글
 
+  case userProfile(user: User)         // 타 유저 프로필 보기
+
   // 관심
   case favorite                        // 관심 피드 루트
 

--- a/Bragit/App/Flow/SearchFlow.swift
+++ b/Bragit/App/Flow/SearchFlow.swift
@@ -1,0 +1,90 @@
+//
+//  SearchFlow.swift
+//  Bragit
+//
+//  Created by 이태윤 on 9/9/25.
+//
+import UIKit
+import RxFlow
+
+final class SearchFlow: Flow {
+  var root: Presentable { nav }
+  private let nav = UINavigationController()
+
+
+  func navigate(to step: Step) -> FlowContributors {
+    guard let step = step as? AppStep else { return .none }
+    switch step {
+    case .searchFeed:
+      return showSearchRoot()
+
+    case .dismiss:
+      nav.dismiss(animated: true)
+      return .none
+
+    case .pop:
+      nav.popViewController(animated: true)
+      return .none
+
+    case .tagInform(let tag):
+      return searchShowTagDetail(tag: tag)
+
+    case .feedDetail(let post):
+      return searchShowDetailPost(post: post)
+
+    case .userProfile(let user):
+      return searchShowUserProfile(user: user)
+
+    default:
+      return .none
+    }
+  }
+
+  private func showSearchRoot() -> FlowContributors {
+    let reactor = SearchReactor()
+    let searchVC = SearchViewController(reactor: reactor)
+
+    nav.setViewControllers([searchVC], animated: true)
+
+    return .one(flowContributor: .contribute(
+      withNextPresentable: searchVC,
+      withNextStepper: reactor
+    ))
+  }
+
+  func searchShowTagDetail(tag: Tag) -> FlowContributors {
+    let reactor = TagDetailReactor(tag: tag)
+    let tagDetailVC = TagDetailViewController(reactor: reactor)
+
+    nav.pushViewController(tagDetailVC, animated: true)
+
+    return .one(flowContributor: .contribute(
+      withNextPresentable: tagDetailVC,
+      withNextStepper: reactor
+    ))
+  }
+
+  func searchShowDetailPost(post: Post) -> FlowContributors {
+    let reactor = DetailPostReactor(post: post)
+    let detailPostVC = DetailPostViewController(reactor: reactor)
+
+    nav.pushViewController(detailPostVC, animated: true)
+
+    return .one(flowContributor: .contribute(
+      withNextPresentable: detailPostVC,
+      withNextStepper: reactor
+    ))
+  }
+
+  func searchShowUserProfile(user: User) -> FlowContributors {
+    let reactor = UserProfileReactor(user: user)
+    let userProfileVC = UserProfileViewCotnroller(reactor: reactor)
+
+    nav.pushViewController(userProfileVC, animated: true)
+
+    return .one(flowContributor: .contribute(
+      withNextPresentable: userProfileVC,
+      withNextStepper: reactor
+    ))
+  }
+}

--- a/Bragit/App/Flow/TabFlow.swift
+++ b/Bragit/App/Flow/TabFlow.swift
@@ -168,17 +168,15 @@ final class TabFlow: NSObject, Flow, Stepper {
   }
 
   func showsearchView() -> FlowContributors {
-    guard let navigation = rootViewController.selectedViewController as? UINavigationController else { return .none }
-    let reactor = SearchReactor()
-    let searchVC = SearchViewController(reactor: reactor)
-
-    searchVC.modalPresentationStyle = .fullScreen
-    searchVC.modalTransitionStyle = .crossDissolve
-    navigation.present(searchVC, animated: true)
-
+    let flow = SearchFlow() // 모달로 띄울 전용 플로우
+    Flows.use(flow, when: .ready) { [weak self] root in
+      root.modalPresentationStyle = .fullScreen
+      root.modalTransitionStyle = .crossDissolve
+      self?.rootViewController.present(root, animated: true)
+    }
     return .one(flowContributor: .contribute(
-      withNextPresentable: searchVC,
-      withNextStepper: reactor
+      withNextPresentable: flow,
+      withNextStepper: OneStepper(withSingleStep: AppStep.searchFeed)
     ))
   }
 

--- a/Bragit/App/Flow/TabFlow.swift
+++ b/Bragit/App/Flow/TabFlow.swift
@@ -47,6 +47,8 @@ final class TabFlow: NSObject, Flow, Stepper {
       return showTagDetail(tag: tag)
     case .searchFeed:
       return showsearchView()
+    case .userProfile(let user):
+      return showUserProfile(user: user)
     default:
       return .one(flowContributor: .forwardToParentFlow(withStep: step))
     }
@@ -176,6 +178,19 @@ final class TabFlow: NSObject, Flow, Stepper {
 
     return .one(flowContributor: .contribute(
       withNextPresentable: searchVC,
+      withNextStepper: reactor
+    ))
+  }
+
+  func showUserProfile(user: User) -> FlowContributors {
+    guard let navigation = rootViewController.selectedViewController as? UINavigationController else { return .none }
+    let reactor = UserProfileReactor(user: user)
+    let userProfileVC = UserProfileViewCotnroller(reactor: reactor)
+
+    navigation.pushViewController(userProfileVC, animated: true)
+
+    return .one(flowContributor: .contribute(
+      withNextPresentable: userProfileVC,
       withNextStepper: reactor
     ))
   }

--- a/Bragit/Model/SearchModel.swift
+++ b/Bragit/Model/SearchModel.swift
@@ -40,7 +40,7 @@ enum SearchRow: Hashable {
 
 struct SearchTagItem: Hashable {
   let id: UUID = UUID()
-  let tag: String
+  let tag: Tag
 }
 
 struct SearchPostItem: Hashable {

--- a/Bragit/Presentation/DetailPost/DetailPostReactor.swift
+++ b/Bragit/Presentation/DetailPost/DetailPostReactor.swift
@@ -187,16 +187,8 @@ class DetailPostReactor: Reactor, Stepper {
       return Observable.concat([
         .just(.setLoading(true)),
         postManager.rxDeletePost(postId: post.id.uuidString)
-          .do{ _ in
-            #if DEBUG
-            print("[DetailPostReactor] delete success")
-            #endif
-          }
           .map { _ in Mutation.setDeleted }
           .catch { error in
-            #if DEBUG
-            print("[DetailPostReactor] delete error: \(error.localizedDescription)")
-            #endif
             return .just(.setError(error))
           },
         .just(.setLoading(false))

--- a/Bragit/Presentation/DetailPost/DetailPostReactor.swift
+++ b/Bragit/Presentation/DetailPost/DetailPostReactor.swift
@@ -55,6 +55,7 @@ class DetailPostReactor: Reactor, Stepper {
     var isLiked: Bool               // 좋아요 눌렀는지
     var likeCount: Int              // 좋아요 수
     var isfollowed: Bool            // 팔로우 여부
+    var withdrewUser: Bool          // 탈퇴유저 체크
   }
 
   init(post: Post) {
@@ -69,9 +70,11 @@ class DetailPostReactor: Reactor, Stepper {
       viewer: post.author?.id == nowUser,
       isLiked: likePosts?.contains { $0 == post.id.uuidString } ?? false,
       likeCount: post.like,
-      isfollowed: followUser?.contains { $0 == post.author?.id } ?? false
+      isfollowed: followUser?.contains { $0 == post.author?.id } ?? false,
+      withdrewUser: post.author?.nickname == nil
     )
     self.post = post
+
   }
 
   // Action이 들어왔을 때 어떤 Mutation으로 바뀔지 정의

--- a/Bragit/Presentation/DetailPost/DetailPostReactor.swift
+++ b/Bragit/Presentation/DetailPost/DetailPostReactor.swift
@@ -33,6 +33,7 @@ class DetailPostReactor: Reactor, Stepper {
     case didTapEdit
     case didTapReport
     case didTapDelete
+    case didTapUserProfile
   }
 
   // 상태변경 이벤트 정의 (상태를 어떻게 바꿀 것인가)
@@ -184,9 +185,6 @@ class DetailPostReactor: Reactor, Stepper {
       return .empty()
 
     case .didTapDelete:
-      #if DEBUG
-      print("[DetailPostReactor] didTapDelete: postId=\(post.id.uuidString)")
-      #endif
       return Observable.concat([
         .just(.setLoading(true)),
         postManager.rxDeletePost(postId: post.id.uuidString)
@@ -196,6 +194,22 @@ class DetailPostReactor: Reactor, Stepper {
           },
         .just(.setLoading(false))
       ])
+    case .didTapUserProfile:
+      guard let authorId = post.author?.id, !authorId.isEmpty else {
+        return .empty()
+      }
+
+      return userManager
+        .rxfetchUsersBy(ids: [authorId])
+        .compactMap { $0.first }
+        .do { [weak self] user in
+          self?.steps.accept(AppStep.userProfile(user: user))
+        }
+        .flatMap { _ in Observable<Mutation>.empty() }
+        .catch { error in
+          print("fetch user failed:", error)
+          return .empty()
+        }
     }
   }
   // swiftlint:enable cyclomatic_complexity

--- a/Bragit/Presentation/DetailPost/DetailPostViewController.swift
+++ b/Bragit/Presentation/DetailPost/DetailPostViewController.swift
@@ -145,8 +145,8 @@ class DetailPostViewController: UIViewController, View {
     titleView.addSubview(uploadDateLabel)
     titleView.addSubview(titleLabel)
     titleView.addSubview(profileImage)
-    titleView.addSubview(followButton)
     titleView.addSubview(nickNameLabel)
+    titleView.addSubview(followButton)
     titleView.addSubview(dividerView)
 
     view.addSubview(bottomView)
@@ -326,6 +326,11 @@ class DetailPostViewController: UIViewController, View {
           differentMenu.show(in: view, sourcePoint: sourcePoint)
         }
       }
+      .disposed(by: disposeBag)
+
+    profileImage.rx.tap
+      .map { Reactor.Action.didTapUserProfile }
+      .bind(to: reactor.action)
       .disposed(by: disposeBag)
 
     followButton.rx.tap

--- a/Bragit/Presentation/DetailPost/DetailPostViewController.swift
+++ b/Bragit/Presentation/DetailPost/DetailPostViewController.swift
@@ -125,13 +125,6 @@ class DetailPostViewController: UIViewController, View {
     view.backgroundColor = .white
 
     setUIConstraints()
-    print("제목 : \(String(describing: reactor?.currentState.title))")
-    print("내용 : \(String(describing: reactor?.currentState.content))")
-    print("닉네임 : \(String(describing: reactor?.currentState.nickName))")
-    print("보는사람(작성자인지): \(String(describing: reactor?.currentState.viewer))")
-    print("작성자ID: \(String(describing: reactor?.post.author?.id))")
-    print("보는사람ID: \(String(describing: reactor?.nowUser))")
-
   }
 
   // UI 설정
@@ -369,7 +362,7 @@ class DetailPostViewController: UIViewController, View {
           followButton.setTitle("팔로잉", for: .normal)
           followButton.backgroundColor = .grayScale100
         }
-        if state.viewer == true {
+        if state.viewer == true || state.withdrewUser == true {
           followButton.isHidden = true
         }
         // 프로필 이미지 nil이면 기본 이미지 유지

--- a/Bragit/Presentation/DetailPost/DetailPostViewController.swift
+++ b/Bragit/Presentation/DetailPost/DetailPostViewController.swift
@@ -333,6 +333,11 @@ class DetailPostViewController: UIViewController, View {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
 
+    nickNameLabel.rx.tap
+      .map { Reactor.Action.didTapUserProfile }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+
     followButton.rx.tap
       .map { Reactor.Action.didTapFollow }
       .bind(to: reactor.action)

--- a/Bragit/Presentation/Favorite/FavoriteFeedView.swift
+++ b/Bragit/Presentation/Favorite/FavoriteFeedView.swift
@@ -36,7 +36,7 @@ final class FavoriteFeedView: UIView {
       $0.refreshControl = refreshControl
     }
 
-  private lazy var dataSource = makeFavoriteCollectionViewDataSource(self.collectionView)
+  lazy var dataSource = makeFavoriteCollectionViewDataSource(self.collectionView)
 
   override init(frame: CGRect) {
     super.init(frame: frame)

--- a/Bragit/Presentation/Favorite/FavoriteReactor.swift
+++ b/Bragit/Presentation/Favorite/FavoriteReactor.swift
@@ -39,6 +39,7 @@ class FavoriteReactor: Reactor, Stepper {
     case goToTagDetail(Tag)
     case refresh
     case searchTapped
+    case didTapPost(Post)
   }
 
   enum Mutation {
@@ -210,6 +211,9 @@ class FavoriteReactor: Reactor, Stepper {
       return rxSetPost(postType: currentState.postType)
     case .searchTapped:
       steps.accept(AppStep.searchFeed)
+      return .empty()
+    case .didTapPost(let post):
+      self.steps.accept(AppStep.feedDetail(post: post))
       return .empty()
     }
   }

--- a/Bragit/Presentation/Favorite/FavoriteViewController.swift
+++ b/Bragit/Presentation/Favorite/FavoriteViewController.swift
@@ -150,6 +150,21 @@ class FavoriteViewController: UIViewController, View {
       .map { Reactor.Action.searchTapped }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+
+    favoriteView.feedView.collectionView.rx.itemSelected
+      .compactMap { [weak self] indexPath -> Post? in
+        guard let self, let item = self.favoriteView.feedView.dataSource.itemIdentifier(for: indexPath)
+        else { return nil }
+        switch item {
+        case .post(let post):
+          return post
+        default:
+          return nil
+        }
+      }
+      .map { post in Reactor.Action.didTapPost(post) }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
   }
 
   func scrollToTop() {

--- a/Bragit/Presentation/Search/SearchReactor.swift
+++ b/Bragit/Presentation/Search/SearchReactor.swift
@@ -168,7 +168,7 @@ class SearchReactor: Reactor, Stepper {
   }
 
   func transform(state: Observable<State>) -> Observable<State> {
-    state.observe(on: MainScheduler.instance)
+    return state.observe(on: MainScheduler.instance)
   }
 
   private func saveRecent(_ raw: String) {

--- a/Bragit/Presentation/Search/SearchReactor.swift
+++ b/Bragit/Presentation/Search/SearchReactor.swift
@@ -25,9 +25,13 @@ class SearchReactor: Reactor, Stepper {
     case viewDidLoad
     case updateText(String)
     case submit
+    case submitWithQuery(String, Bool)
     case clearAllRecent
     case deleteRecent(String)
     case changeScope(SearchScope)
+    case didTapTag(Tag)
+    case didTapPost(Post)
+    case didTapUser(User)
     case didTapBack
   }
   // 상태변경 이벤트 정의 (상태를 어떻게 바꿀 것인가)
@@ -42,14 +46,14 @@ class SearchReactor: Reactor, Stepper {
 
   // View의 상태 정의 (현재 View의 상태값)
   struct State {
-    var text: String = ""
-    var suggestions: [String] = []
-    var recent: [String]?
-    var tagResults: [SearchTagItem] = []
-    var postResults: [SearchPostItem] = []
-    var userResults: [SearchUserItem] = []
-    var scope: SearchScope = .tag
-    var mode: SearchMode = .recent
+    var text: String = ""                      // 검색창 텍스트
+    var suggestions: [String] = []             // 입력 중 연관어
+    var recent: [String]?                      // 최근 검색어
+    var tagResults: [SearchTagItem] = []       // 태그 결과
+    var postResults: [SearchPostItem] = []     // 게시글 결과
+    var userResults: [SearchUserItem] = []     // 사용자 결과
+    var scope: SearchScope = .tag              // 현재 결과 탭
+    var mode: SearchMode = .recent             // 화면 모드 (최근/입력중/결과)
   }
 
   init() {
@@ -60,48 +64,45 @@ class SearchReactor: Reactor, Stepper {
   // 사용자 입력 → 상태 변화 신호로 변환
   func mutate(action: Action) -> Observable<Mutation> {
     switch action {
+
     case .viewDidLoad:
+      // 진입 시 최근검색 불러오고 모드는 '최근'으로
       return .concat([
         .just(.setRecent(recentSearches)),
         .just(.setMode(.recent))
       ])
 
     case .updateText(let raw):
+      // 공백·개행 제거
       let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      // 공백이면 최근 검색 모드로 복귀 + 추천 비우기
       if trimmed.isEmpty {
         return .concat([
           .just(.setText("")),
           .just(.setMode(.recent)),
           .just(.setSuggestions([]))
         ])
-      } else {
-        let suggest = tagManager
-          .rxSearchTags(searchText: trimmed, page: 0, pageSize: 10)
-          .map { $0.map { $0.tag } }
-          .map(Mutation.setSuggestions)
-        return .concat([
-          .just(.setText(trimmed)),
-          .just(.setMode(.typingSuggestions)),
-          suggest
-        ])
       }
+
+      // 입력 중: 텍스트 반영 → 모드 전환(typing) → 태그 추천 조회
+      let suggest = tagManager
+        .rxSearchTags(searchText: trimmed, page: 0, pageSize: 10)
+        .map { $0.map { $0.tag } }
+        .map(Mutation.setSuggestions)
+
+      return .concat([
+        .just(.setText(trimmed)),
+        .just(.setMode(.typingSuggestions)),
+        suggest
+      ])
+
     case .submit:
       let trimmed = currentState.text.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty else { return .empty() }
-      saveRecent(trimmed)
-      let search = searchManager.rxSearchAll(searchText: trimmed, page: 0, pageSize: 20)
-        .map { bundle -> Mutation in
-          let tagItems = bundle.tags.map { SearchTagItem(tag: $0.tag) }
-          let postItems = bundle.posts.map { SearchPostItem(post: $0) }
-          let userItems = bundle.users.map { SearchUserItem(user: $0) }
-          return .setResults(tags: tagItems, posts: postItems, users: userItems)
-        }
-      return .concat([
-        .just(.setMode(.results)),
-        search,
-        .just(.setSuggestions([])),
-        .just(.setRecent(recentSearches))
-      ])
+      return performSearch(for: trimmed, saveToRecent: true)
+
+    case let .submitWithQuery(query, save):
+      return performSearch(for: query, saveToRecent: save)
 
     case .clearAllRecent:
       recentSearches = []
@@ -115,6 +116,18 @@ class SearchReactor: Reactor, Stepper {
 
     case .changeScope(let scope):
       return .just(.setScope(scope))
+
+    case .didTapTag(let tag):
+      steps.accept(AppStep.tagInform(tag))
+      return .empty()
+
+    case .didTapPost(let post):
+      steps.accept(AppStep.feedDetail(post: post))
+      return .empty()
+
+    case .didTapUser(let user):
+      steps.accept(AppStep.userProfile(user: user))
+      return .empty()
 
     case .didTapBack:
       steps.accept(AppStep.dismiss)
@@ -170,28 +183,47 @@ class SearchReactor: Reactor, Stepper {
   func transform(state: Observable<State>) -> Observable<State> {
     return state.observe(on: MainScheduler.instance)
   }
+}
 
-  private func saveRecent(_ raw: String) {
+private extension SearchReactor {
+  func performSearch(for query: String, saveToRecent: Bool) -> Observable<Mutation> {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return .empty() }
+    if saveToRecent {
+      saveRecent(trimmed)
+    }
+
+    let search = searchManager.rxSearchAll(searchText: trimmed, page: 0, pageSize: 20)
+      .map { bundle -> Mutation in
+        let tagItems = bundle.tags.map { SearchTagItem(tag: $0) }
+        let postItems = bundle.posts.map { SearchPostItem(post: $0) }
+        let userItems = bundle.users.map { SearchUserItem(user: $0) }
+        return .setResults(tags: tagItems, posts: postItems, users: userItems)
+      }
+
+    // 모드 전환 → 결과 세팅 → 추천 비우기 → 최근검색 재반영
+    return .concat([
+      .just(.setMode(.results)),
+      search,
+      .just(.setSuggestions([])),
+      .just(.setRecent(recentSearches))
+    ])
+  }
+
+  // 최근검색 저장
+  func saveRecent(_ raw: String) {
     let trimmedQuery = raw.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmedQuery.isEmpty else { return }
 
     var list = recentSearches ?? []
+    // 대소문자 무시 중복 제거
     list.removeAll { $0.caseInsensitiveCompare(trimmedQuery) == .orderedSame }
+    // 맨 앞에 삽입
     list.insert(trimmedQuery, at: 0)
-    // 최근 검색어 20개만 저장
+    // 최대 20개 유지
     if list.count > 20 {
       list.removeLast(list.count - 20)
     }
     recentSearches = list
-  }
-
-  private func removeRecent(_ keyword: String) {
-    var list = recentSearches ?? []
-    list.removeAll { $0.caseInsensitiveCompare(keyword) == .orderedSame }
-    recentSearches = list
-  }
-
-  private func clearAllRecent() {
-    recentSearches = []
   }
 }

--- a/Bragit/Presentation/Search/SearchViewContoller.swift
+++ b/Bragit/Presentation/Search/SearchViewContoller.swift
@@ -96,6 +96,12 @@ final class SearchViewController: UIViewController, View {
   }
 
   func bind(reactor: SearchReactor) {
+    rx.viewDidAppear
+      .take(1)
+      .map { _ in SearchReactor.Action.viewDidLoad }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+
     backButton.rx.tap
       .map { SearchReactor.Action.didTapBack }
       .bind(to: reactor.action)
@@ -119,9 +125,36 @@ final class SearchViewController: UIViewController, View {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
 
-    rx.viewDidAppear
-      .take(1)
-      .map { _ in SearchReactor.Action.viewDidLoad }
+    searchCollectionView.rx.itemSelected
+      .compactMap { [weak self] indexPath -> SearchRow? in
+        guard let self else { return nil }
+
+        searchCollectionView.deselectItem(at: indexPath, animated: true)
+
+        return dataSource.itemIdentifier(for: indexPath)
+      }
+      .do { [weak self] _ in
+        self?.view.endEditing(true)
+      }
+      .flatMap { row -> Observable<SearchReactor.Action> in
+        switch row {
+
+        case .recentKeyword(let text), .suggestion(let text):
+          return .just(.submitWithQuery(text, true))
+
+        case .tag(let item):
+          return .just(.didTapTag(item.tag))
+
+        case .post(let item):
+          return .just(.didTapPost(item.post))
+
+        case .user(let item):
+          return .just(.didTapUser(item.user))
+
+        default:
+          return .empty()
+        }
+      }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
 
@@ -367,7 +400,7 @@ final class SearchViewController: UIViewController, View {
   private struct Registrations {
     let recent: UICollectionView.CellRegistration<RecentCell, String>
     let suggestion: UICollectionView.CellRegistration<UICollectionViewListCell, String>
-    let tag: UICollectionView.CellRegistration<UICollectionViewListCell, String>
+    let tag: UICollectionView.CellRegistration<UICollectionViewListCell, SearchTagItem>
     let post: UICollectionView.CellRegistration<PostCell, SearchPostItem>
     let user: UICollectionView.CellRegistration<UserCell, SearchUserItem>
     let empty: UICollectionView.CellRegistration<EmptyCell, Void>
@@ -392,12 +425,14 @@ final class SearchViewController: UIViewController, View {
       cell.contentConfiguration = content
     }
 
-    let tagReg = UICollectionView.CellRegistration<UICollectionViewListCell, String> { cell, _, item in
+    let tagReg = UICollectionView.CellRegistration<UICollectionViewListCell, SearchTagItem> { cell, _, item in
       var content = cell.defaultContentConfiguration()
       content.image = .hashTag
       content.imageProperties.tintColor = .grayScale900
       content.imageProperties.reservedLayoutSize = CGSize(width: 20, height: 20)
-      content.text = item
+
+      content.text = item.tag.tag
+
       content.textProperties.font = .pretendard(size: 15)
       content.textProperties.color = .grayScale900
       content.imageToTextPadding = 8
@@ -444,7 +479,7 @@ final class SearchViewController: UIViewController, View {
         case .suggestion(let text):
           return collectionView.dequeueConfiguredReusableCell(using: regs.suggestion, for: indexPath, item: text)
         case .tag(let item):
-          return collectionView.dequeueConfiguredReusableCell(using: regs.tag, for: indexPath, item: item.tag)
+          return collectionView.dequeueConfiguredReusableCell(using: regs.tag, for: indexPath, item: item)
         case .post(let item):
           return collectionView.dequeueConfiguredReusableCell(using: regs.post, for: indexPath, item: item)
         case .user(let item):

--- a/Bragit/Presentation/Splash/SplashViewController.swift
+++ b/Bragit/Presentation/Splash/SplashViewController.swift
@@ -48,7 +48,7 @@ final class SplashViewController: UIViewController, Stepper {
         self.animationView.loadAnimation(from: dot)
         DispatchQueue.main.async {
           self.view.layoutIfNeeded()
-          self.animationView.play { [weak self] finished in
+          self.animationView.play { [weak self] _ in
             guard let self = self else { return }
             UIView.animate(withDuration: 0.18, delay: 0.0, options: [.curveEaseInOut], animations: {
               self.animationView.alpha = 0.0
@@ -59,12 +59,12 @@ final class SplashViewController: UIViewController, Stepper {
             })
           }
         }
-      case .failure(let error):
+      case .failure(_):
         if let anim = LottieAnimation.named("splash") {
           self.animationView.animation = anim
           DispatchQueue.main.async {
             self.view.layoutIfNeeded()
-            self.animationView.play { [weak self] finished in
+            self.animationView.play { [weak self] _ in
               guard let self = self else { return }
               UIView.animate(withDuration: 0.18, delay: 0.0, options: [.curveEaseInOut], animations: {
                 self.animationView.alpha = 0.0
@@ -76,9 +76,9 @@ final class SplashViewController: UIViewController, Stepper {
             }
           }
         } else {
-          if let path = Bundle.main.path(forResource: "splash", ofType: "lottie") {
+          if Bundle.main.path(forResource: "splash", ofType: "lottie") != nil {
           } else {
-            print("🔎 Not found via Bundle.path(forResource:ofType:)")
+            print("Not found via Bundle.path(forResource:ofType:)")
           }
         }
       }

--- a/Bragit/Presentation/UserProfile/UserProfileReactor.swift
+++ b/Bragit/Presentation/UserProfile/UserProfileReactor.swift
@@ -1,0 +1,55 @@
+//
+//  UserProfileReactor.swift
+//  Bragit
+//
+//  Created by 이태윤 on 9/8/25.
+//
+import ReactorKit
+import RxSwift
+import RxFlow
+import RxRelay
+import Then
+import Dependencies
+
+class UserProfileReactor: Reactor, Stepper {
+  var initialState: State
+  let user: User
+  let steps = PublishRelay<Step>()
+
+  private let disposeBag = DisposeBag()
+  // 사용자 액션 정의 (사용자의 의도)
+  enum Action {
+  }
+
+  // 상태변경 이벤트 정의 (상태를 어떻게 바꿀 것인가)
+  enum Mutation {
+  }
+
+  // View의 상태 정의 (현재 View의 상태값)
+  struct State: Then {
+  }
+
+  init(user: User) {
+    self.user = user
+    self.initialState = State()
+  }
+
+  // Action이 들어왔을 때 어떤 Mutation으로 바뀔지 정의
+  // 사용자 입력 → 상태 변화 신호로 변환
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+
+    }
+
+    // Mutation이 발생했을 때 상태(State)를 실제로 바꿈
+    // 상태 변화 신호 → 실제 상태 반영
+    func reduce(state: State, mutation: Mutation) -> State {
+      switch mutation {
+      }
+    }
+
+    func transform(state: Observable<State>) -> Observable<State> {
+      return state.observe(on: MainScheduler.instance)
+    }
+  }
+}

--- a/Bragit/Presentation/UserProfile/UserProfileViewCotnroller.swift
+++ b/Bragit/Presentation/UserProfile/UserProfileViewCotnroller.swift
@@ -16,6 +16,7 @@ class UserProfileViewCotnroller: UIViewController, View {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.navigationController?.navigationBar.isHidden = true
+    view.backgroundColor = .red
   }
 
   init(reactor: UserProfileReactor) {

--- a/Bragit/Presentation/UserProfile/UserProfileViewCotnroller.swift
+++ b/Bragit/Presentation/UserProfile/UserProfileViewCotnroller.swift
@@ -1,0 +1,32 @@
+//
+//  UserProfileViewCotnroller.swift
+//  Bragit
+//
+//  Created by 이태윤 on 9/8/25.
+//
+import UIKit
+
+import RxCocoa
+import RxSwift
+import ReactorKit
+
+class UserProfileViewCotnroller: UIViewController, View {
+  var disposeBag = DisposeBag()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.navigationController?.navigationBar.isHidden = true
+  }
+
+  init(reactor: UserProfileReactor) {
+    super.init(nibName: nil, bundle: nil)
+    self.reactor = reactor
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func bind(reactor: UserProfileReactor) {
+  }
+}

--- a/Bragit/Util/Reactive+.swift
+++ b/Bragit/Util/Reactive+.swift
@@ -90,3 +90,14 @@ extension Reactive where Base: UIImageView {
     return ControlEvent(events: source)
   }
 }
+
+extension Reactive where Base: UILabel {
+  // 라발 탭 이벤트 방출 유틸
+  var tap: ControlEvent<Void> {
+    base.isUserInteractionEnabled = true
+    let gesture = UITapGestureRecognizer()
+    base.addGestureRecognizer(gesture)
+    let source = gesture.rx.event.map { _ in () }
+    return ControlEvent(events: source)
+  }
+}

--- a/Bragit/Util/Reactive+.swift
+++ b/Bragit/Util/Reactive+.swift
@@ -75,3 +75,18 @@ extension Reactive where Base: UIViewController {
     return ControlEvent(events: source)
   }
 }
+
+extension Reactive where Base: UIImageView {
+  // 이미지뷰 탭 이벤트 방출 유틸
+  var tap: ControlEvent<Void> {
+    base.isUserInteractionEnabled = true
+    let gesture = UITapGestureRecognizer()
+    base.addGestureRecognizer(gesture)
+
+    let source = gesture.rx.event
+      .filter { $0.state == .ended }
+      .map { _ in () }
+
+    return ControlEvent(events: source)
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

close #89 

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 후 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

-  린트 경고 해소
-  관심 피드 게시글 상세 연결
- 탈퇴한 유저 팔로우 버튼 숨기기
- 다른유저 페이지 보기 플로우 연결
- 게시물에서 유저 프로필 클릭시 유저 프로필 화면으로 이동
- reactive 이미지뷰 라벨 터치 이벤트 유틸 생성
- 화면전환 이상해지던 문제 Flow를 추가해서 해결했습니다. 검색이아닌 상태에서 태그, 게시물, 유저페이지 기존대로 이동됩니다.

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.

- 

## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.

-  imageView랑 Label rx.tap 가능합니다.
