### PR TITLE
🚨 Fix: 작성자 본인인데 불구하고 팔로우 버튼이 사라지지 않는 문제 해결

### DIFF
--- a/Bragit/Presentation/DetailPost/DetailPostReactor.swift
+++ b/Bragit/Presentation/DetailPost/DetailPostReactor.swift
@@ -66,7 +66,7 @@ class DetailPostReactor: Reactor, Stepper {
       content: DetailPostReactor.unarchivedContent(content: post.content),
       nickName: post.author?.nickname ?? "탈퇴한 유저 입니다",
       profileImage: post.author?.profile ?? nil,
-      viewer: post.author?.id == nowUser,
+      viewer: post.author?.id.lowercased() == nowUser?.lowercased(),
       isLiked: likePosts?.contains { $0 == post.id.uuidString } ?? false,
       likeCount: post.like,
       isfollowed: followUser?.contains { $0 == post.author?.id } ?? false


### PR DESCRIPTION
## 🔗 관련 이슈

close #95 

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 후 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- 작성자 id와 접속된 유저의 id의 대소문자 때에 viewer가 false로 뜨는 문제였습니다. 그래서 둘다 소문자로 lowercased를 사용하여 비교했습니다.

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.

- 

## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.

- 
