### PR TITLE
🔨: 전체적인 버그 잡이

### DIFF
--- a/Bragit/App/Flow/AppStep.swift
+++ b/Bragit/App/Flow/AppStep.swift
@@ -67,4 +67,3 @@ enum AppStep: Step {
   // 태그
   case tagInform(Tag)     // 태그 정보
 }
-

--- a/Bragit/App/Flow/AppStep.swift
+++ b/Bragit/App/Flow/AppStep.swift
@@ -15,7 +15,7 @@ enum AppStep: Step {
 
   // 인증/가입
   case login                           // 로그인 화면 (최초 진입)
-  case signup(initialMail: String?, refreshToken: String?)    // 애플 회원가입 시작
+  case signup(initialMail: String?, refreshToken: String?, isAppleLogin: Bool)    // 회원가입 시작
   case signTermsConset                 // 약관 동의
   case signServiceConsent              // 서비스 이용 약관 동의
   case signPersonalInfoConsent         // 개인정보 수집 동의
@@ -67,3 +67,4 @@ enum AppStep: Step {
   // 태그
   case tagInform(Tag)     // 태그 정보
 }
+

--- a/Bragit/App/Flow/AppStep.swift
+++ b/Bragit/App/Flow/AppStep.swift
@@ -15,13 +15,14 @@ enum AppStep: Step {
 
   // 인증/가입
   case login                           // 로그인 화면 (최초 진입)
-  case signup(initialMail: String?, refreshToken: String?)    // 회원가입 시작
+  case signup(initialMail: String?, refreshToken: String?)    // 애플 회원가입 시작
   case signTermsConset                 // 약관 동의
   case signServiceConsent              // 서비스 이용 약관 동의
   case signPersonalInfoConsent         // 개인정보 수집 동의
   case signMarketingConsent            // 마케팅 정보 수집 동의
   case signupPhoto                     // 프로필 사진 설정
   case signSelectTag(profileURL: String?)                   // 선호 태그 선택
+  case signInMail                      // 메일 로그인
   case findPwd                         // 비밀번호 찾기
   case setPwd                          // 비밀번호 재설정
 

--- a/Bragit/App/Flow/LoginFlow.swift
+++ b/Bragit/App/Flow/LoginFlow.swift
@@ -1,3 +1,5 @@
+import RxFlow
+import RxRelay
 //
 //  LoginFlow.swift
 //  Bragit
@@ -5,9 +7,6 @@
 //  Created by 이태윤 on 8/25/25.
 //
 import UIKit
-
-import RxFlow
-import RxRelay
 
 // 로그인 화면 네비게이션 전담
 final class LoginFlow: Flow, Stepper {
@@ -21,8 +20,8 @@ final class LoginFlow: Flow, Stepper {
     switch step {
     case .login:
       return showLogin()
-    case .signup(let initialMail, let refreshToken):
-      return showSignup(initialMail: initialMail, refreshToken: refreshToken)
+    case .signup(let initialMail, let refreshToken, let isAppleLogin):
+      return showSignup(initialMail: initialMail, refreshToken: refreshToken, isAppleLogin: isAppleLogin)
     case .signTermsConset:
       return showTermsConsent()
     case .signupPhoto:
@@ -61,8 +60,12 @@ final class LoginFlow: Flow, Stepper {
     )
   }
 
-  private func showSignup(initialMail: String?, refreshToken: String?) -> FlowContributors {
-    let userInfoVC = UserInfoViewController(initialMail: initialMail, refreshToken: refreshToken)
+  private func showSignup(initialMail: String?, refreshToken: String?, isAppleLogin: Bool) -> FlowContributors {
+    let userInfoVC = UserInfoViewController(
+      initialMail: initialMail,
+      refreshToken: refreshToken,
+      isAppleLogin: isAppleLogin
+    )
     userInfoVC.onNext = { [weak self] (info: UserRegistrationInfo) in
       print("[Flow]: \(initialMail as Any)")
       self?.pendingUserInfo = info
@@ -128,4 +131,3 @@ final class LoginFlow: Flow, Stepper {
     )
   }
 }
-

--- a/Bragit/App/Flow/LoginFlow.swift
+++ b/Bragit/App/Flow/LoginFlow.swift
@@ -29,8 +29,19 @@ final class LoginFlow: Flow, Stepper {
       return showSignupPhoto()
     case .signSelectTag(let profileURL):
       return showSignSelectTag(profileURL: profileURL)
+    case .signInMail:
+      return showMailLogin()
     case .home:
       return .end(forwardToParentFlowWithStep: AppStep.home)
+
+    // 추가: 뒤로 가기(pop) / dismiss 처리
+    case .pop:
+      nav.popViewController(animated: true)
+      return .none
+    case .dismiss:
+      nav.dismiss(animated: true)
+      return .none
+
     default:
       return .none
     }
@@ -98,4 +109,23 @@ final class LoginFlow: Flow, Stepper {
         )
     )
   }
+
+  private func showMailLogin() -> FlowContributors {
+    let reactor = MailLoginReactor()
+    let mailLoginVC = MailLoginViewController(reactor: reactor)
+
+    // 시스템 내비게이션 바의 뒤로가기 버튼 숨김
+    mailLoginVC.navigationItem.hidesBackButton = true
+    mailLoginVC.navigationItem.leftBarButtonItem = nil
+    mailLoginVC.navigationItem.title = ""
+
+    nav.pushViewController(mailLoginVC, animated: true)
+    return .one(
+      flowContributor: .contribute(
+        withNextPresentable: mailLoginVC,
+        withNextStepper: reactor
+      )
+    )
+  }
 }
+

--- a/Bragit/App/Flow/LoginFlow.swift
+++ b/Bragit/App/Flow/LoginFlow.swift
@@ -1,5 +1,3 @@
-import RxFlow
-import RxRelay
 //
 //  LoginFlow.swift
 //  Bragit
@@ -7,6 +5,9 @@ import RxRelay
 //  Created by 이태윤 on 8/25/25.
 //
 import UIKit
+
+import RxFlow
+import RxRelay
 
 // 로그인 화면 네비게이션 전담
 final class LoginFlow: Flow, Stepper {

--- a/Bragit/Presentation/Auth/ImageUpload/ImageUploadViewController.swift
+++ b/Bragit/Presentation/Auth/ImageUpload/ImageUploadViewController.swift
@@ -177,12 +177,48 @@ extension ImageUploadViewController {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
 
-    reactor.state
+    // 로딩 상태
+    let loading = reactor.state
       .map(\.isLoading)
       .distinctUntilChanged()
-      .bind(with: self) { owner, loading in
-        owner.view.isUserInteractionEnabled = !loading
-        print("[UI] isLoading=\(loading), interactionEnabled=\(!loading)")
+      .share(replay: 1)
+
+    loading
+      .bind(with: self) { owner, isLoading in
+        owner.view.isUserInteractionEnabled = !isLoading
+        print("[UI] isLoading=\(isLoading), interactionEnabled=\(!isLoading)")
+      }
+      .disposed(by: disposeBag)
+
+    // 이미지 선택 여부
+    let hasImage = reactor.state
+      .map { $0.imageData != nil }
+      .distinctUntilChanged()
+      .share(replay: 1)
+
+    // 이미지가 있을 때 next 활성, 로딩 중엔 비활성
+    Observable.combineLatest(hasImage, loading)
+      .map { hasImage, isLoading in hasImage && !isLoading }
+      .bind(to: nextButton.rx.isEnabled)
+      .disposed(by: disposeBag)
+
+    Observable.combineLatest(hasImage, loading)
+      .map { hasImage, isLoading in (hasImage && !isLoading) ? 1.0 : 0.5 }
+      .bind(with: self) { owner, alpha in
+        owner.nextButton.alpha = alpha
+      }
+      .disposed(by: disposeBag)
+
+    // 이미지가 없을 때 beLater 활성, 로딩 중엔 비활성
+    Observable.combineLatest(hasImage, loading)
+      .map { hasImage, isLoading in !hasImage && !isLoading }
+      .bind(to: beLaterButton.rx.isEnabled)
+      .disposed(by: disposeBag)
+
+    Observable.combineLatest(hasImage, loading)
+      .map { hasImage, isLoading in (!hasImage && !isLoading) ? 1.0 : 0.5 }
+      .bind(with: self) { owner, alpha in
+        owner.beLaterButton.alpha = alpha
       }
       .disposed(by: disposeBag)
   }

--- a/Bragit/Presentation/Auth/Login/LoginReactor.swift
+++ b/Bragit/Presentation/Auth/Login/LoginReactor.swift
@@ -85,7 +85,8 @@ final class LoginReactor: Reactor, Stepper {
       steps.accept(AppStep.signInMail)
       return .empty()
     case .tapSignUp:
-      steps.accept(AppStep.signup(initialMail: nil, refreshToken: nil))
+      // 일반(메일) 회원가입 시작
+      steps.accept(AppStep.signup(initialMail: nil, refreshToken: nil, isAppleLogin: false))
       return .empty()
     case .tapNext:
       steps.accept(AppStep.home)
@@ -153,7 +154,15 @@ final class LoginReactor: Reactor, Stepper {
             await MainActor.run { self.steps.accept(AppStep.home) }
           } else {
             // 미가입: 회원가입 플로우로 (TagCheckReactor에서 nowUser 저장)
-            await MainActor.run { self.steps.accept(AppStep.signup(initialMail: mail, refreshToken: refreshToken)) }
+            await MainActor.run {
+              self.steps.accept(
+                AppStep.signup(
+                  initialMail: mail,
+                  refreshToken: refreshToken,
+                  isAppleLogin: true
+                )
+              )
+            }
           }
           observer.onCompleted()
         } catch {
@@ -233,3 +242,4 @@ final class LoginReactor: Reactor, Stepper {
     }
   }
 }
+

--- a/Bragit/Presentation/Auth/Login/LoginReactor.swift
+++ b/Bragit/Presentation/Auth/Login/LoginReactor.swift
@@ -75,7 +75,7 @@ final class LoginReactor: Reactor, Stepper {
             return self.checkUserRegistrationAndRoute(mail: mail, refreshToken: refreshToken)
           },
         .just(.setLoading(false)),
-        .just(.setNonce(raw: nil, hashed: nil)),
+        .just(.setNonce(raw: nil, hashed: nil))
       ])
     case .tapAppleButton:
       let raw = Self.randomNonce()
@@ -242,4 +242,3 @@ final class LoginReactor: Reactor, Stepper {
     }
   }
 }
-

--- a/Bragit/Presentation/Auth/Login/LoginReactor.swift
+++ b/Bragit/Presentation/Auth/Login/LoginReactor.swift
@@ -10,9 +10,10 @@
 // 3. UserChecker.exists(uid) -> true면 메인, false면 회원가입 각각 state 방출
 // 아 리액트 어렵다
 
+import Foundation
+
 import CryptoKit
 import Dependencies
-import Foundation
 import Functions
 import ReactorKit
 import RxFlow

--- a/Bragit/Presentation/Auth/Login/LoginReactor.swift
+++ b/Bragit/Presentation/Auth/Login/LoginReactor.swift
@@ -28,6 +28,7 @@ final class LoginReactor: Reactor, Stepper {
     case tapAppleButton
     case tapSignUp
     case tapNext
+    case tapMailLogin
   }
 
   // 내부 상태 변경
@@ -80,6 +81,9 @@ final class LoginReactor: Reactor, Stepper {
       let raw = Self.randomNonce()
       let hashed = Self.sha256(raw)
       return .just(.setNonce(raw: raw, hashed: hashed))
+    case .tapMailLogin:
+      steps.accept(AppStep.signInMail)
+      return .empty()
     case .tapSignUp:
       steps.accept(AppStep.signup(initialMail: nil, refreshToken: nil))
       return .empty()

--- a/Bragit/Presentation/Auth/Login/LoginViewController.swift
+++ b/Bragit/Presentation/Auth/Login/LoginViewController.swift
@@ -62,13 +62,13 @@ final class LoginViewController: UIViewController, View {
     $0.layer.borderColor = UIColor(named: "grayScale100")?.cgColor
     $0.layer.cornerRadius = 12
     $0.backgroundColor = UIColor(red: 0.97, green: 0.97, blue: 0.97, alpha: 1)
-    $0.isEnabled = false
+    $0.isEnabled = true
   }
 
   let signUpButton = UIButton(type: .system).then {
     $0.setTitle("회원 가입하기", for: .normal)
     $0.setTitleColor(UIColor(red: 0.439, green: 0.439, blue: 0.439, alpha: 1), for: .normal)
-    $0.isEnabled = false
+    $0.isEnabled = true
   }
 
   init(reactor: LoginReactor) {

--- a/Bragit/Presentation/Auth/Login/LoginViewController.swift
+++ b/Bragit/Presentation/Auth/Login/LoginViewController.swift
@@ -37,12 +37,14 @@ final class LoginViewController: UIViewController, View {
     $0.backgroundColor = .white
     $0.layer.borderColor = UIColor(named: "grayScale100")?.cgColor
     $0.setTitle("Google로 로그인(아직)", for: .normal)
+    $0.isEnabled = false
   }
 
   let kakaoButton = UIButton(type: .system).then {
     $0.layer.cornerRadius = 12
     $0.backgroundColor = UIColor(red: 0.996, green: 0.898, blue: 0, alpha: 1)
     $0.setTitle("카카오로 로그인􀀲", for: .normal)
+    $0.isEnabled = false
   }
 
   let appleButton = ASAuthorizationAppleIDButton(type: .signIn, style: .black).then {
@@ -60,11 +62,13 @@ final class LoginViewController: UIViewController, View {
     $0.layer.borderColor = UIColor(named: "grayScale100")?.cgColor
     $0.layer.cornerRadius = 12
     $0.backgroundColor = UIColor(red: 0.97, green: 0.97, blue: 0.97, alpha: 1)
+    $0.isEnabled = false
   }
 
   let signUpButton = UIButton(type: .system).then {
     $0.setTitle("회원 가입하기", for: .normal)
     $0.setTitleColor(UIColor(red: 0.439, green: 0.439, blue: 0.439, alpha: 1), for: .normal)
+    $0.isEnabled = false
   }
 
   init(reactor: LoginReactor) {
@@ -149,6 +153,12 @@ final class LoginViewController: UIViewController, View {
       }
       .disposed(by: disposeBag)
 
+    mailButton.rx.controlEvent(.touchUpInside)
+      .subscribe(with: self) { owner, _ in
+        owner.reactor?.action.onNext(.tapMailLogin)
+      }
+      .disposed(by: disposeBag)
+
     // 회원가입 버튼
     signUpButton.rx.controlEvent(.touchUpInside)
       .subscribe(with: self) { owner, _ in
@@ -192,6 +202,10 @@ extension LoginViewController:
     controller.delegate = self
     controller.presentationContextProvider = self
     controller.performRequests()
+  }
+
+  private func showEmailLoginAlert() {
+  //
   }
 
   func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {

--- a/Bragit/Presentation/Auth/MailLogin/MailLoginReactor.swift
+++ b/Bragit/Presentation/Auth/MailLogin/MailLoginReactor.swift
@@ -5,8 +5,9 @@
 //  Created by luca on 9/9/25.
 //
 
-import Dependencies
 import Foundation
+
+import Dependencies
 import ReactorKit
 import RxFlow
 import RxRelay

--- a/Bragit/Presentation/Auth/MailLogin/MailLoginReactor.swift
+++ b/Bragit/Presentation/Auth/MailLogin/MailLoginReactor.swift
@@ -1,0 +1,155 @@
+//
+//  MailLoginReactor.swift
+//  Bragit
+//
+//  Created by luca on 9/9/25.
+//
+
+import Dependencies
+import Foundation
+import ReactorKit
+import RxFlow
+import RxRelay
+import RxSwift
+import Supabase
+
+final class MailLoginReactor: Reactor, Stepper {
+  typealias Reactor = MailLoginReactor
+  enum Action {
+    case tapBack
+    case updateEmail(String)
+    case updatePassword(String)
+    case tapLogin
+    case tapForgotPassword
+  }
+
+  enum Mutation {
+    case setEmail(String)
+    case setPassword(String)
+    case setMailValid(Bool)
+    case setPasswordValid(Bool)
+    case setLoading(Bool)
+    case setError(String?)
+  }
+
+  struct State {
+    var mail: String = ""
+    var password: String = ""
+    var isMailValid: Bool = false
+    var isPasswordValid: Bool = false
+    var isLoading: Bool = false
+    var errorMessage: String?
+    var canLogin: Bool {
+      isMailValid && isPasswordValid && !isLoading
+    }
+  }
+
+  let initialState: State
+  let steps = PublishRelay<Step>()
+  @Dependency(\.supabase) private var supabase
+  @Dependency(\.authClient) private var authClient
+
+  init() {
+    self.initialState = State()
+  }
+
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case .tapBack:
+      steps.accept(AppStep.pop)
+      return .empty()
+    case .updateEmail(let mail):
+      let isValid = UserInfoValidator.isValidMail(mail)
+      return .concat([
+        .just(.setEmail(mail)),
+        .just(.setMailValid(isValid))
+      ])
+    case .updatePassword(let password):
+      let isValid = UserInfoValidator.isValidPassword(password)
+      return .concat([
+        .just(.setPassword(password)),
+        .just(.setPasswordValid(isValid))
+      ])
+    case .tapLogin:
+      guard currentState.canLogin else { return .empty() }
+      return performLogin()
+    case .tapForgotPassword:
+      steps.accept(AppStep.findPwd)
+      return .empty()
+    }
+  }
+
+  func reduce(state: State, mutation: Mutation) -> State {
+    var newState = state
+    switch mutation {
+    case .setEmail(let mail):
+      newState.mail = mail
+    case .setPassword(let password):
+      newState.password = password
+    case .setMailValid(let valid):
+      newState.isMailValid = valid
+    case .setPasswordValid(let valid):
+      newState.isPasswordValid = valid
+    case .setLoading(let loading):
+      newState.isLoading = loading
+      if loading {
+        newState.errorMessage = nil
+      }
+    case .setError(let message):
+      newState.errorMessage = message
+    }
+    return newState
+  }
+
+  // 중요: 상태 스트림을 메인 스레드로 보냅니다.
+  func transform(state: Observable<State>) -> Observable<State> {
+    state.observe(on: MainScheduler.instance)
+  }
+
+  private func performLogin() -> Observable<Mutation> {
+    return Observable.create { [weak self] observer in
+      guard let self else {
+        observer.onCompleted()
+        return Disposables.create()
+      }
+
+      Task {
+        do {
+          observer.onNext(.setLoading(true))
+
+          try await self.supabase.auth.signIn(
+            email: self.currentState.mail,
+            password: self.currentState.password
+          )
+
+          let session = try await self.supabase.auth.session
+          let userId = session.user.id.uuidString
+
+          UserDefaults.standard.set(userId, forKey: LocalStorageCase.nowUser.rawValue)
+
+          observer.onNext(.setLoading(false))
+          observer.onCompleted()
+
+          await MainActor.run {
+            self.steps.accept(AppStep.home)
+          }
+        } catch {
+          let errorMessage: String
+          if error.localizedDescription.contains("Invalid login credentials") {
+            errorMessage = "이메일 또는 비밀번호가 이상함"
+          } else if error.localizedDescription.contains("Email not confirmed") {
+            errorMessage = "이메일 인증이 필요"
+          } else {
+            errorMessage = "로그인 실패: \(error.localizedDescription)"
+          }
+
+          observer.onNext(.setError(errorMessage))
+          observer.onNext(.setLoading(false))
+          observer.onCompleted()
+        }
+      }
+      return Disposables.create()
+    }
+  }
+}
+

--- a/Bragit/Presentation/Auth/MailLogin/MailLoginReactor.swift
+++ b/Bragit/Presentation/Auth/MailLogin/MailLoginReactor.swift
@@ -152,4 +152,3 @@ final class MailLoginReactor: Reactor, Stepper {
     }
   }
 }
-

--- a/Bragit/Presentation/Auth/MailLogin/MailLoginViewController.swift
+++ b/Bragit/Presentation/Auth/MailLogin/MailLoginViewController.swift
@@ -1,0 +1,303 @@
+//
+//  MailLoginViewController.swift
+//  Bragit
+//
+//  Created by luca on 9/9/25.
+//
+
+import ReactorKit
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+import UIKit
+
+final class MailLoginViewController: UIViewController, View {
+  typealias Reactor = MailLoginReactor
+  var disposeBag = DisposeBag()
+
+  private let headerView = UIView()
+  private let backButton = UIButton(type: .system).then {
+    $0.setImage(.back, for: .normal)
+    $0.tintColor = .grayScale900
+  }
+
+  private let titleLabel = UILabel().then {
+    $0.text = "로그인"
+    $0.font = UIFont.systemFont(ofSize: 16)
+    $0.textColor = .grayScale900
+    $0.textAlignment = .center
+  }
+
+  private let scrollView = UIScrollView().then {
+    $0.keyboardDismissMode = .interactive
+    $0.alwaysBounceVertical = true
+    $0.showsVerticalScrollIndicator = false
+    $0.contentInsetAdjustmentBehavior = .never
+  }
+
+  private let contentView = UIView()
+
+  private let mailLabel = UILabel().then {
+    $0.text = "이메일"
+    $0.font = .pretendard(size: 13, weight: .medium)
+    $0.textColor = .grayScale700
+  }
+
+  private let mailTextField = InsetTextField().then {
+    $0.placeholder = "Bragit@bragit.com"
+    $0.font = .pretendard(size: 14, weight: .regular)
+    $0.textColor = .grayScale900
+    $0.backgroundColor = .white
+    $0.layer.cornerRadius = 14
+    $0.layer.borderWidth = 1
+    $0.layer.borderColor = UIColor.grayScale100.cgColor
+    $0.clearButtonMode = .whileEditing
+    $0.autocapitalizationType = .none
+    $0.autocorrectionType = .no
+    $0.spellCheckingType = .no
+    $0.keyboardType = .emailAddress
+    $0.returnKeyType = .next
+  }
+
+  private let passwordLabel = UILabel().then {
+    $0.text = "비밀번호"
+    $0.font = .pretendard(size: 13, weight: .medium)
+    $0.textColor = .grayScale700
+  }
+
+  private let passwordTextField = InsetTextField().then {
+    $0.placeholder = "8-24자 사이 영문, 숫자, 특수문자"
+    $0.font = .pretendard(size: 14, weight: .regular)
+    $0.textColor = .grayScale900
+    $0.backgroundColor = .white
+    $0.layer.cornerRadius = 14
+    $0.layer.borderWidth = 1
+    $0.layer.borderColor = UIColor.grayScale100.cgColor
+    $0.clearButtonMode = .whileEditing
+    $0.isSecureTextEntry = true
+    $0.autocorrectionType = .no
+    $0.spellCheckingType = .no
+    $0.textContentType = .password
+    $0.returnKeyType = .done
+  }
+
+  private let loginButton = UIButton(type: .system).then {
+    $0.setTitle("확인", for: .normal)
+    $0.titleLabel?.font = .pretendard(size: 16, weight: .medium)
+    $0.setTitleColor(.grayScale900, for: .normal)
+    $0.backgroundColor = .primary400
+    $0.layer.cornerRadius = 12
+    $0.isEnabled = false
+    $0.alpha = 0.5
+  }
+
+  private let forgotPasswordButton = UIButton(type: .system).then {
+    $0.setTitle("비밀번호를 잊으셨나요?", for: .normal)
+    $0.titleLabel?.font = .pretendard(size: 16, weight: .regular)
+    $0.setTitleColor(.grayScale700, for: .normal)
+    $0.contentHorizontalAlignment = .center
+  }
+
+  private let activityIndicator = UIActivityIndicatorView(style: .medium).then {
+    $0.hidesWhenStopped = true
+    $0.isUserInteractionEnabled = false
+  }
+
+  private lazy var dismissTapGesture: UITapGestureRecognizer = {
+    let tap = UITapGestureRecognizer()
+    tap.cancelsTouchesInView = false
+    return tap
+  }()
+
+  init(reactor: MailLoginReactor) {
+    super.init(nibName: nil, bundle: nil)
+    self.reactor = reactor
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    navigationController?.setNavigationBarHidden(true, animated: false)
+  }
+
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+    setupLayout()
+    view.addGestureRecognizer(dismissTapGesture)
+    mailTextField.delegate = self
+    passwordTextField.delegate = self
+  }
+
+  private func setupLayout() {
+    view.addSubview(headerView)
+    headerView.addSubview(backButton)
+    headerView.addSubview(titleLabel)
+    view.addSubview(scrollView)
+    scrollView.addSubview(contentView)
+    view.addSubview(activityIndicator)
+
+    [mailLabel, mailTextField, passwordLabel, passwordTextField, loginButton, forgotPasswordButton].forEach {
+      contentView.addSubview($0)
+    }
+
+    headerView.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide)
+      $0.leading.trailing.equalToSuperview()
+      $0.height.equalTo(58)
+    }
+
+    backButton.snp.makeConstraints {
+      $0.leading.equalToSuperview().offset(20)
+      $0.centerY.equalToSuperview()
+    }
+
+    titleLabel.snp.makeConstraints {
+      $0.centerX.centerY.equalToSuperview()
+    }
+
+    scrollView.snp.makeConstraints {
+      $0.top.equalTo(headerView.snp.bottom)
+      $0.leading.trailing.bottom.equalToSuperview()
+    }
+
+    contentView.snp.makeConstraints {
+      $0.edges.equalTo(scrollView.contentLayoutGuide)
+      $0.width.equalTo(scrollView.frameLayoutGuide)
+      // height 제약 제거: 맨 마지막 뷰의 bottom으로 콘텐츠 높이 확정
+    }
+
+    mailLabel.snp.makeConstraints {
+      $0.top.equalTo(contentView.snp.top).offset(32)
+      $0.leading.trailing.equalToSuperview().inset(20)
+    }
+
+    mailTextField.snp.makeConstraints {
+      $0.top.equalTo(mailLabel.snp.bottom).offset(8)
+      $0.leading.trailing.equalToSuperview().inset(20)
+      $0.height.equalTo(52)
+    }
+
+    passwordLabel.snp.makeConstraints {
+      $0.top.equalTo(mailTextField.snp.bottom).offset(20)
+      $0.leading.trailing.equalToSuperview().inset(20)
+    }
+
+    passwordTextField.snp.makeConstraints {
+      $0.top.equalTo(passwordLabel.snp.bottom).offset(8)
+      $0.leading.trailing.equalToSuperview().inset(20)
+      $0.height.equalTo(52)
+    }
+
+    loginButton.snp.makeConstraints {
+      $0.top.equalTo(passwordTextField.snp.bottom).offset(48)
+      $0.leading.trailing.equalToSuperview().inset(20)
+      $0.height.equalTo(36)
+    }
+
+    forgotPasswordButton.snp.makeConstraints {
+      $0.top.equalTo(loginButton.snp.bottom).offset(36)
+      $0.leading.trailing.equalToSuperview()
+      // centerX 제거(수평 중복 제약 방지), 아래 제약으로 콘텐츠 높이 결정
+      $0.bottom.equalToSuperview().inset(24)
+    }
+
+    activityIndicator.snp.makeConstraints {
+      $0.center.equalToSuperview()
+    }
+  }
+
+  func bind(reactor: MailLoginReactor) {
+    backButton.rx.tap
+      .map { Reactor.Action.tapBack }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+
+    mailTextField.rx.text.orEmpty
+      .distinctUntilChanged()
+      .map { Reactor.Action.updateEmail($0) }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+
+    passwordTextField.rx.text.orEmpty
+      .distinctUntilChanged()
+      .map { Reactor.Action.updatePassword($0) }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+
+    loginButton.rx.tap
+      .map { Reactor.Action.tapLogin }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+
+    forgotPasswordButton.rx.tap
+      .map { Reactor.Action.tapForgotPassword }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+
+    dismissTapGesture.rx.event
+      .bind { [weak self] _ in
+        self?.view.endEditing(true)
+      }
+      .disposed(by: disposeBag)
+
+    reactor.state.map { $0.canLogin }
+      .distinctUntilChanged()
+      .bind { [weak self] canLogin in
+        self?.loginButton.isEnabled = canLogin
+        self?.loginButton.alpha = canLogin ? 1.0 : 0.5
+      }
+      .disposed(by: disposeBag)
+
+    reactor.state.map { $0.isLoading }
+      .distinctUntilChanged()
+      .bind { [weak self] isLoading in
+        if isLoading {
+          self?.activityIndicator.startAnimating()
+        } else {
+          self?.activityIndicator.stopAnimating()
+        }
+        self?.view.isUserInteractionEnabled = !isLoading
+      }
+      .disposed(by: disposeBag)
+
+    // 안전한 Alert 표시: 메인 스레드 보장, 중복/타이밍 이슈 방지
+    reactor.state
+      .map { $0.errorMessage }
+      .distinctUntilChanged { $0 == $1 } // 동일 메시지 중복 방지
+      .compactMap { $0 }
+      .observe(on: MainScheduler.instance)
+      .withUnretained(self)
+      .bind(onNext: { vc, message in
+        guard vc.isViewLoaded, vc.view.window != nil else { return }
+        guard vc.presentedViewController == nil else { return }
+
+        let alert = UIAlertController(title: "오류", message: message, preferredStyle: .alert)
+        alert.addAction(.init(title: "확인", style: .default))
+        vc.present(alert, animated: true)
+      })
+      .disposed(by: disposeBag)
+  }
+}
+
+extension MailLoginViewController: UITextFieldDelegate {
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    if textField == mailTextField {
+      passwordTextField.becomeFirstResponder()
+    } else if textField == passwordTextField {
+      if reactor?.currentState.canLogin == true {
+        reactor?.action.onNext(.tapLogin)
+      }
+      textField.resignFirstResponder()
+    }
+    return true
+  }
+}

--- a/Bragit/Presentation/Auth/MailLogin/MailLoginViewController.swift
+++ b/Bragit/Presentation/Auth/MailLogin/MailLoginViewController.swift
@@ -276,13 +276,13 @@ final class MailLoginViewController: UIViewController, View {
       .compactMap { $0 }
       .observe(on: MainScheduler.instance)
       .withUnretained(self)
-      .bind(onNext: { vc, message in
-        guard vc.isViewLoaded, vc.view.window != nil else { return }
-        guard vc.presentedViewController == nil else { return }
+      .bind(onNext: { viewController, message in
+        guard viewController.isViewLoaded, viewController.view.window != nil else { return }
+        guard viewController.presentedViewController == nil else { return }
 
         let alert = UIAlertController(title: "오류", message: message, preferredStyle: .alert)
         alert.addAction(.init(title: "확인", style: .default))
-        vc.present(alert, animated: true)
+        viewController.present(alert, animated: true)
       })
       .disposed(by: disposeBag)
   }

--- a/Bragit/Presentation/Auth/MailLogin/MailLoginViewController.swift
+++ b/Bragit/Presentation/Auth/MailLogin/MailLoginViewController.swift
@@ -5,12 +5,13 @@
 //  Created by luca on 9/9/25.
 //
 
+import UIKit
+
 import ReactorKit
 import RxCocoa
 import RxSwift
 import SnapKit
 import Then
-import UIKit
 
 final class MailLoginViewController: UIViewController, View {
   typealias Reactor = MailLoginReactor

--- a/Bragit/Presentation/Auth/MailLogin/MailLoginViewController.swift
+++ b/Bragit/Presentation/Auth/MailLogin/MailLoginViewController.swift
@@ -124,10 +124,6 @@ final class MailLoginViewController: UIViewController, View {
     navigationController?.setNavigationBarHidden(true, animated: false)
   }
 
-  override func viewWillDisappear(_ animated: Bool) {
-    super.viewWillDisappear(animated)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = .systemBackground
@@ -276,14 +272,14 @@ final class MailLoginViewController: UIViewController, View {
       .compactMap { $0 }
       .observe(on: MainScheduler.instance)
       .withUnretained(self)
-      .bind(onNext: { viewController, message in
+      .bind { viewController, message in
         guard viewController.isViewLoaded, viewController.view.window != nil else { return }
         guard viewController.presentedViewController == nil else { return }
 
         let alert = UIAlertController(title: "오류", message: message, preferredStyle: .alert)
         alert.addAction(.init(title: "확인", style: .default))
         viewController.present(alert, animated: true)
-      })
+      }
       .disposed(by: disposeBag)
   }
 }

--- a/Bragit/Presentation/Auth/SignUp/UserInfoReactor.swift
+++ b/Bragit/Presentation/Auth/SignUp/UserInfoReactor.swift
@@ -1,0 +1,77 @@
+// UserInfoReactor.swift
+import Foundation
+import Dependencies
+import ReactorKit
+import RxSwift
+
+final class UserInfoReactor: Reactor {
+  enum Action {
+    case validateNickname(String)
+  }
+
+  enum Mutation {
+    case setChecking(Bool)
+    case setNickname(valid: Bool, text: String)
+  }
+
+  struct State {
+    var isChecking: Bool = false
+    var nicknameValid: Bool = false
+    var nicknameStatusText: String = " "
+  }
+
+  let initialState: State
+  @Dependency(\.userManager) private var userManager
+
+  init() {
+    self.initialState = State()
+  }
+
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case .validateNickname(let raw):
+      let name = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      // 1) 로컬 형식 검증 먼저
+      guard UserInfoValidator.isValidNickname(name) else {
+        return .just(.setNickname(valid: false, text: "사용 불가한 닉네임입니다"))
+      }
+
+      // 2) 서버 중복 체크
+      let start = Observable.just(Mutation.setChecking(true))
+      let check = userManager.rxhasNickName(nickName: name)
+        .map { isTaken -> Mutation in
+          if isTaken {
+            return .setNickname(valid: false, text: "사용 중인 닉네임입니다")
+          } else {
+            return .setNickname(valid: true, text: "사용 가능한 닉네임입니다")
+          }
+        }
+        .catch { _ in
+          .just(.setNickname(valid: false, text: "닉네임 확인 실패"))
+        }
+      let end = Observable.just(Mutation.setChecking(false))
+
+      return .concat([start, check, end])
+    }
+  }
+
+  func reduce(state: State, mutation: Mutation) -> State {
+    var newState = state
+    switch mutation {
+    case .setChecking(let flag):
+      newState.isChecking = flag
+      if flag {
+        newState.nicknameStatusText = "중복 확인 중..."
+      }
+    case .setNickname(let valid, let text):
+      newState.nicknameValid = valid
+      newState.nicknameStatusText = text
+    }
+    return newState
+  }
+
+  func transform(state: Observable<State>) -> Observable<State> {
+    state.observe(on: MainScheduler.instance)
+  }
+}

--- a/Bragit/Presentation/Auth/SignUp/UserInfoReactor.swift
+++ b/Bragit/Presentation/Auth/SignUp/UserInfoReactor.swift
@@ -1,5 +1,7 @@
 // UserInfoReactor.swift
+
 import Foundation
+
 import Dependencies
 import ReactorKit
 import RxSwift

--- a/Bragit/Presentation/Auth/SignUp/UserInfoValidator.swift
+++ b/Bragit/Presentation/Auth/SignUp/UserInfoValidator.swift
@@ -34,4 +34,3 @@ enum UserInfoValidator {
     return regex.firstMatch(in: text, options: [], range: range) != nil
   }
 }
-

--- a/Bragit/Presentation/Auth/SignUp/UserInfoViewController.swift
+++ b/Bragit/Presentation/Auth/SignUp/UserInfoViewController.swift
@@ -1,6 +1,7 @@
+import UIKit
+
 import SnapKit
 import Then
-import UIKit
 import ReactorKit
 import RxSwift
 import RxCocoa

--- a/Bragit/Presentation/Auth/SignUp/UserInfoViewController.swift
+++ b/Bragit/Presentation/Auth/SignUp/UserInfoViewController.swift
@@ -116,13 +116,13 @@ final class UserInfoFormView: UIView {
       $0.textColor = labelColor
     }
     pwTextField.do {
-      $0.placeholder = "8-24자 영문/숫자/특수기호"
+      $0.placeholder = "8-24자 사이 영문, 숫자, 특수문자"
       $0.layer.borderColor = UIColor(named: "grayScale100")?.cgColor
       $0.layer.borderWidth = 1
       $0.layer.cornerRadius = 14
       $0.isEnabled = true
       $0.isSecureTextEntry = true
-      $0.textContentType = .oneTimeCode
+      $0.textContentType = .password
       $0.clearButtonMode = .whileEditing
       $0.font = textFont
       $0.textColor = fontColor
@@ -153,13 +153,13 @@ final class UserInfoFormView: UIView {
       $0.textColor = labelColor
     }
     rePwTextField.do {
-      $0.placeholder = "8-24자 영문/숫자/특수기호"
+      $0.placeholder = "8-24자 사이 영문, 숫자, 특수문자"
       $0.layer.borderColor = UIColor(named: "grayScale100")?.cgColor
       $0.layer.borderWidth = 1
       $0.layer.cornerRadius = 14
       $0.isEnabled = true
       $0.isSecureTextEntry = true
-      $0.textContentType = .oneTimeCode
+      $0.textContentType = .password
       $0.clearButtonMode = .whileEditing
       $0.font = textFont
       $0.textColor = fontColor
@@ -555,23 +555,29 @@ extension UserInfoViewController {
       let confirm = confirmRaw.trimmingCharacters(in: .whitespacesAndNewlines)
 
       passwordValid = UserInfoValidator.isValidPassword(pwd)
-      confirmMatched = (pwd == confirm) && !pwd.isEmpty
+      // let confirm = formView.rePwTextField.text ?? ""
+
+      if !confirm.isEmpty {
+        confirmMatched = (pwd == confirm)
+      }
 
       applyCheckState(
         icon: formView.pwCheckIcon,
         label: formView.pwCheckLabel,
         okStatus: passwordValid,
         okText: "사용 가능한 비밀번호입니다",
-        failText: "형식에 맞지 않는 비밀번호입니다"
+        failText: "사용 불가한 비밀번호입니다"
       )
 
-      applyCheckState(
-        icon: formView.rePwCheckIcon,
-        label: formView.rePwCheckLabel,
-        okStatus: confirmMatched,
-        okText: "비밀번호가 일치합니다",
-        failText: "비밀번호가 불일치합니다"
-      )
+      if !confirm.isEmpty {
+        applyCheckState(
+          icon: formView.rePwCheckIcon,
+          label: formView.rePwCheckLabel,
+          okStatus: confirmMatched,
+          okText: "비밀번호가 일치합니다",
+          failText: "비밀번호가 불일치합니다"
+        )
+      }
     }
     updateNextButton()
   }

--- a/Bragit/Presentation/Auth/SignUp/UserInfoViewController.swift
+++ b/Bragit/Presentation/Auth/SignUp/UserInfoViewController.swift
@@ -92,6 +92,7 @@ final class UserInfoFormView: UIView {
       $0.autocapitalizationType = .none
       $0.spellCheckingType = .no
       $0.autocorrectionType = .no
+      $0.textContentType = .username
     }
     mailCheckIcon.do {
       $0.contentMode = .scaleAspectFit
@@ -129,6 +130,7 @@ final class UserInfoFormView: UIView {
       $0.returnKeyType = .next
       $0.spellCheckingType = .no
       $0.autocorrectionType = .no
+      $0.autocapitalizationType = .none
     }
     pwCheckIcon.do {
       $0.contentMode = .scaleAspectFit
@@ -166,6 +168,7 @@ final class UserInfoFormView: UIView {
       $0.returnKeyType = .next
       $0.spellCheckingType = .no
       $0.autocorrectionType = .no
+      $0.autocapitalizationType = .none
     }
     rePwCheckIcon.do {
       $0.contentMode = .scaleAspectFit
@@ -297,7 +300,7 @@ final class UserInfoViewController: UIViewController {
   var onNext: ((UserRegistrationInfo) -> Void)?
 
   private let initialMail: String?
-  private var isAppleLogin: Bool { initialMail?.isEmpty == false }
+  private var isAppleLogin: Bool
   private let refreshToken: String?
 
   fileprivate var mailValid = false
@@ -306,24 +309,18 @@ final class UserInfoViewController: UIViewController {
   fileprivate var nicknameValid = false
 
   private let formView = UserInfoFormView()
-
-  private lazy var inputOrder: [UITextField] = [
-    formView.mailTextField,
-    formView.pwTextField,
-    formView.rePwTextField,
-    formView.nicknameTextField
-  ]
-
+  private var inputOrder: [UITextField] = []
   private var keyboardBottomInset: CGFloat = 0
   private weak var currentFirstResponder: UITextField?
 
-  init(initialMail: String?, refreshToken: String?) {
+  init(initialMail: String?, refreshToken: String?, isAppleLogin: Bool) {
     if let space = initialMail?.trimmingCharacters(in: .whitespacesAndNewlines), !space.isEmpty {
       self.initialMail = space
     } else {
       self.initialMail = nil
     }
     self.refreshToken = refreshToken
+    self.isAppleLogin = isAppleLogin
     super.init(nibName: nil, bundle: nil)
   }
   required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -334,6 +331,7 @@ final class UserInfoViewController: UIViewController {
     super.viewDidLoad()
     title = "회원가입"
     configureInitialState()
+    configureInputOrder()
     configureTargets()
     configureDelegates()
     addKeyboardDismissGesture()
@@ -407,22 +405,39 @@ final class UserInfoViewController: UIViewController {
     NotificationCenter.default.removeObserver(self)
   }
 
+  private func setFieldDisabled(_ textField: UITextField, dim: Bool = true) {
+    textField.isEnabled = false
+    textField.isUserInteractionEnabled = false
+    if dim { textField.alpha = 0.5 }
+  }
+
   private func configureInitialState() {
-    if let mail = initialMail {
-      formView.mailTextField.text = mail
-      [formView.mailTextField, formView.pwTextField, formView.rePwTextField].forEach { $0.isEnabled = false }
+    if isAppleLogin {
+      // 애플 로그인 시 이메일 필드에 고정 문구 표시 (백엔드 저장은 하지 않음)
+      formView.mailTextField.text = "Apple Social Login"
+
+      // 아이디/비번/확인 비활성화
+      [formView.mailTextField, formView.pwTextField, formView.rePwTextField].forEach {
+        setFieldDisabled($0, dim: true)
+      }
+
+      // 시각적 피드백(검증 성공 상태 표시)
       [formView.pwTextField, formView.rePwTextField].forEach {
         $0.text = String(repeating: "•", count: 8)
         $0.isSecureTextEntry = true
       }
 
-      formView.mailCheckLabel.text = "사용 가능한 이메일입니다"
+      // 체크 라벨 텍스트도 애플 계정 안내로 표시
+      let appleInfoText = "Apple 계정을 이용 중입니다"
+      formView.mailCheckLabel.text = appleInfoText
+      formView.pwCheckLabel.text = appleInfoText
+      formView.rePwCheckLabel.text = appleInfoText
+
+      // 아이콘/색상은 긍정(accept) 상태로 유지
       formView.mailCheckLabel.textColor = formView.acceptColor
       formView.mailCheckIcon.image = .accept
-      formView.pwCheckLabel.text = "사용 가능한 비밀번호입니다"
       formView.pwCheckLabel.textColor = formView.acceptColor
       formView.pwCheckIcon.image = .accept
-      formView.rePwCheckLabel.text = "비밀번호가 일치합니다"
       formView.rePwCheckLabel.textColor = formView.acceptColor
       formView.rePwCheckIcon.image = .accept
 
@@ -430,19 +445,38 @@ final class UserInfoViewController: UIViewController {
       passwordValid = true
       confirmMatched = true
     } else {
+      // 일반 가입 초기 상태
       formView.mailCheckLabel.text = " "
       formView.mailCheckIcon.image = nil
       formView.pwCheckLabel.text = " "
       formView.pwCheckIcon.image = nil
       formView.rePwCheckLabel.text = " "
       formView.rePwCheckIcon.image = nil
+
+      // 초기 이메일이 있으면 세팅 (메일 가입에서만 의미)
+      if let mail = initialMail {
+        formView.mailTextField.text = mail
+      }
     }
-    print("[UserInfoVC]: \(initialMail as Any)")
+
+    // 닉네임 초기 상태
     formView.nicknameCheckLabel.text = " "
-    formView.nicknameCheckLabel.textColor =
-      formView.labelFont == formView.labelFont ? formView.acceptColor : formView.rejectColor
     formView.nicknameCheckIcon.image = nil
+
     updateNextButton()
+  }
+
+  private func configureInputOrder() {
+    if isAppleLogin {
+      inputOrder = [formView.nicknameTextField]
+    } else {
+      inputOrder = [
+        formView.mailTextField,
+        formView.pwTextField,
+        formView.rePwTextField,
+        formView.nicknameTextField
+      ]
+    }
   }
 
   private func configureTargets() {
@@ -487,8 +521,10 @@ final class UserInfoViewController: UIViewController {
   }
 
   @objc private func onTapNext() {
+    // 메일 가입 외에는 메일을 무시
+    let mailValue = isAppleLogin ? "" : (formView.mailTextField.text ?? "")
     let info = UserRegistrationInfo(
-      mail: formView.mailTextField.text ?? "",
+      mail: mailValue,
       password: isAppleLogin ? nil : formView.pwTextField.text,
       nickname: formView.nicknameTextField.text ?? "",
       isAppleLogin: isAppleLogin,
@@ -510,8 +546,8 @@ extension UserInfoViewController {
         icon: formView.mailCheckIcon,
         label: formView.mailCheckLabel,
         okStatus: true,
-        okText: "사용 가능한 이메일입니다",
-        failText: "사용 불가한 이메일입니다"
+        okText: "Apple 계정을 이용 중입니다",
+        failText: "Apple 계정을 이용 중입니다"
       )
     } else {
       let text = formView.mailTextField.text ?? ""
@@ -537,16 +573,16 @@ extension UserInfoViewController {
         icon: formView.pwCheckIcon,
         label: formView.pwCheckLabel,
         okStatus: true,
-        okText: "사용 가능한 비밀번호입니다",
-        failText: "사용 불가한 비밀번호입니다"
+        okText: "Apple 계정을 이용 중입니다",
+        failText: "Apple 계정을 이용 중입니다"
       )
 
       applyCheckState(
         icon: formView.rePwCheckIcon,
         label: formView.rePwCheckLabel,
         okStatus: true,
-        okText: "비밀번호가 일치합니다",
-        failText: "비밀번호가 불일치합니다"
+        okText: "Apple 계정을 이용 중입니다",
+        failText: "Apple 계정을 이용 중입니다"
       )
     } else {
       let pwdRaw = formView.pwTextField.text ?? ""
@@ -555,7 +591,6 @@ extension UserInfoViewController {
       let confirm = confirmRaw.trimmingCharacters(in: .whitespacesAndNewlines)
 
       passwordValid = UserInfoValidator.isValidPassword(pwd)
-      // let confirm = formView.rePwTextField.text ?? ""
 
       if !confirm.isEmpty {
         confirmMatched = (pwd == confirm)
@@ -590,8 +625,8 @@ extension UserInfoViewController {
         icon: formView.rePwCheckIcon,
         label: formView.rePwCheckLabel,
         okStatus: true,
-        okText: "비밀번호가 일치합니다",
-        failText: "비밀번호가 불일치합니다"
+        okText: "Apple 계정을 이용 중입니다",
+        failText: "Apple 계정을 이용 중입니다"
       )
     } else {
       let pwd = (formView.pwTextField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
@@ -639,6 +674,16 @@ class InsetTextField: UITextField {
 }
 
 extension UserInfoViewController: UITextFieldDelegate {
+  public func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+    // Apple 로그인일 때 이메일/비밀번호/확인 필드는 편집 시작 자체를 방지
+    if isAppleLogin,
+      textField === formView.mailTextField || textField === formView.pwTextField || textField === formView.rePwTextField
+    {
+      return false
+    }
+    return true
+  }
+
   public func textFieldDidBeginEditing(_ textField: UITextField) {
     currentFirstResponder = textField
     let target = textField.convert(textField.bounds, to: formView.scrollView)

--- a/Bragit/Presentation/Auth/SignUp/UserInfoViewController.swift
+++ b/Bragit/Presentation/Auth/SignUp/UserInfoViewController.swift
@@ -1,6 +1,9 @@
 import SnapKit
 import Then
 import UIKit
+import ReactorKit
+import RxSwift
+import RxCocoa
 
 final class UserInfoFormView: UIView {
   let descriptionLabel = UILabel()
@@ -313,6 +316,9 @@ final class UserInfoViewController: UIViewController {
   private var keyboardBottomInset: CGFloat = 0
   private weak var currentFirstResponder: UITextField?
 
+  private let reactorBag = DisposeBag()
+  private let nicknameReactor = UserInfoReactor()
+
   init(initialMail: String?, refreshToken: String?, isAppleLogin: Bool) {
     if let space = initialMail?.trimmingCharacters(in: .whitespacesAndNewlines), !space.isEmpty {
       self.initialMail = space
@@ -336,6 +342,42 @@ final class UserInfoViewController: UIViewController {
     configureDelegates()
     addKeyboardDismissGesture()
     registerKeyboardNotifications()
+    bindNicknameReactor()
+  }
+
+  private func bindNicknameReactor() {
+    // State -> UI
+    nicknameReactor.state
+      .map(\.nicknameStatusText)
+      .distinctUntilChanged()
+      .observe(on: MainScheduler.instance)
+      .subscribe(with: self) { owner, text in
+        owner.formView.nicknameCheckLabel.text = text
+        switch text {
+        case "사용 가능한 닉네임입니다":
+          owner.formView.nicknameCheckLabel.textColor = owner.formView.acceptColor
+          owner.formView.nicknameCheckIcon.image = UIImage.accept.withRenderingMode(.alwaysOriginal)
+        case "사용 중인 닉네임입니다", "닉네임 확인 실패", "사용 불가한 닉네임입니다":
+          owner.formView.nicknameCheckLabel.textColor = owner.formView.rejectColor
+          owner.formView.nicknameCheckIcon.image = UIImage.reject.withRenderingMode(.alwaysOriginal)
+        case "중복 확인 중...":
+          owner.formView.nicknameCheckLabel.textColor = owner.formView.labelColor
+          owner.formView.nicknameCheckIcon.image = nil
+        default:
+          break
+        }
+      }
+      .disposed(by: reactorBag)
+
+    nicknameReactor.state
+      .map(\.nicknameValid)
+      .distinctUntilChanged()
+      .observe(on: MainScheduler.instance)
+      .subscribe(with: self) { owner, valid in
+        owner.nicknameValid = valid
+        owner.updateNextButton()
+      }
+      .disposed(by: reactorBag)
   }
 
   private func registerKeyboardNotifications() {
@@ -413,27 +455,22 @@ final class UserInfoViewController: UIViewController {
 
   private func configureInitialState() {
     if isAppleLogin {
-      // 애플 로그인 시 이메일 필드에 고정 문구 표시 (백엔드 저장은 하지 않음)
-      formView.mailTextField.text = "Apple Social Login"
+      formView.mailTextField.text = "Apple Social Account"
 
-      // 아이디/비번/확인 비활성화
       [formView.mailTextField, formView.pwTextField, formView.rePwTextField].forEach {
         setFieldDisabled($0, dim: true)
       }
 
-      // 시각적 피드백(검증 성공 상태 표시)
       [formView.pwTextField, formView.rePwTextField].forEach {
         $0.text = String(repeating: "•", count: 8)
         $0.isSecureTextEntry = true
       }
 
-      // 체크 라벨 텍스트도 애플 계정 안내로 표시
       let appleInfoText = "Apple 계정을 이용 중입니다"
       formView.mailCheckLabel.text = appleInfoText
       formView.pwCheckLabel.text = appleInfoText
       formView.rePwCheckLabel.text = appleInfoText
 
-      // 아이콘/색상은 긍정(accept) 상태로 유지
       formView.mailCheckLabel.textColor = formView.acceptColor
       formView.mailCheckIcon.image = .accept
       formView.pwCheckLabel.textColor = formView.acceptColor
@@ -445,7 +482,6 @@ final class UserInfoViewController: UIViewController {
       passwordValid = true
       confirmMatched = true
     } else {
-      // 일반 가입 초기 상태
       formView.mailCheckLabel.text = " "
       formView.mailCheckIcon.image = nil
       formView.pwCheckLabel.text = " "
@@ -453,13 +489,11 @@ final class UserInfoViewController: UIViewController {
       formView.rePwCheckLabel.text = " "
       formView.rePwCheckIcon.image = nil
 
-      // 초기 이메일이 있으면 세팅 (메일 가입에서만 의미)
       if let mail = initialMail {
         formView.mailTextField.text = mail
       }
     }
 
-    // 닉네임 초기 상태
     formView.nicknameCheckLabel.text = " "
     formView.nicknameCheckIcon.image = nil
 
@@ -646,17 +680,7 @@ extension UserInfoViewController {
 
   @objc func onNicknameEditingEnd() {
     let name = formView.nicknameTextField.text ?? ""
-    nicknameValid = UserInfoValidator.isValidNickname(name)
-
-    applyCheckState(
-      icon: formView.nicknameCheckIcon,
-      label: formView.nicknameCheckLabel,
-      okStatus: nicknameValid,
-      okText: "사용 가능한 닉네임입니다",
-      failText: "사용 불가한 닉네임입니다"
-    )
-
-    updateNextButton()
+    nicknameReactor.action.onNext(.validateNickname(name))
   }
 }
 
@@ -675,10 +699,10 @@ class InsetTextField: UITextField {
 
 extension UserInfoViewController: UITextFieldDelegate {
   public func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
-    // Apple 로그인일 때 이메일/비밀번호/확인 필드는 편집 시작 자체를 방지
     if isAppleLogin,
-      textField === formView.mailTextField || textField === formView.pwTextField || textField === formView.rePwTextField
-    {
+      textField === formView.mailTextField
+        || textField === formView.pwTextField
+        || textField === formView.rePwTextField {
       return false
     }
     return true

--- a/Bragit/Presentation/Auth/TagCheck/TagCheckReactor.swift
+++ b/Bragit/Presentation/Auth/TagCheck/TagCheckReactor.swift
@@ -76,12 +76,34 @@ final class TagCheckReactor: Reactor, Stepper {
 
       Task {
         do {
+          print("📝: 회원가입 시작 >>> isAppleLogin = \(self.userInfo.isAppleLogin)")
           observer.onNext(.setLoading(true))
 
-          let session = try await self.supabase.auth.session
-          let userUUID = session.user.id
-          let userId = userUUID.uuidString
+          var userId: String
 
+          if !self.userInfo.isAppleLogin {
+            print("📝: 이메일 회원가입 진행 중")
+            guard let password = self.userInfo.password else {
+              print("📝: 비밀번호 없음")
+              observer.onNext(.setError("비밀번호 필요"))
+              observer.onNext(.setLoading(false))
+              observer.onCompleted()
+              return
+            }
+
+            print("📝: signUp 호출 >>> mail = \(self.userInfo.mail)")
+            let signUpResult = try await self.supabase.auth.signUp(
+              email: self.userInfo.mail,
+              password: password
+            )
+            print("📝: signUp 성공")
+
+            let user = signUpResult.user
+            userId = user.id.uuidString
+          } else {
+            let session = try await self.supabase.auth.session
+            userId = session.user.id.uuidString
+          }
           // 현재 로그인한 유저를 로컬에 기억
           UserDefaults.standard.set(userId, forKey: LocalStorageCase.nowUser.rawValue)
 
@@ -112,27 +134,20 @@ final class TagCheckReactor: Reactor, Stepper {
               print("[signup] User_Info.email update failed: \(error)")
             }
           }
-
-          if !trimmedMail.isEmpty {
-            do {
-              try await self.supabase.auth.update(
-                user: UserAttributes(
-                  data: ["email": AnyJSON.string(trimmedMail)]
-                )
-              )
-              print("[signup] auth.user_metadata.email backfilled")
-            } catch {
-              print("[signup] auth.user_metadata.email backfill failed: \(error)")
-            }
-          }
-
           observer.onNext(.setRegistrationComplete(true))
           observer.onNext(.setLoading(false))
           observer.onCompleted()
 
           await MainActor.run { self.steps.accept(AppStep.home) }
         } catch {
-          observer.onNext(.setError("회원가입 중 오류 발생"))
+          print("📝: 에러 >>> \(error)")
+          let errorMessage =
+            if error.localizedDescription.contains("already registered") {
+              "이미 가입된 이메일"
+            } else {
+              "회원가입 중 오류 발생: \(error.localizedDescription)"
+            }
+          observer.onNext(.setError(errorMessage))
           observer.onNext(.setLoading(false))
           observer.onCompleted()
         }

--- a/Bragit/Presentation/Auth/TagCheck/TagCheckReactor.swift
+++ b/Bragit/Presentation/Auth/TagCheck/TagCheckReactor.swift
@@ -5,8 +5,9 @@
 //  Created by luca on 9/2/25.
 //
 
-import Dependencies
 import Foundation
+
+import Dependencies
 import ReactorKit
 import RxFlow
 import RxRelay

--- a/Bragit/Presentation/Auth/TagCheck/TagCheckViewController.swift
+++ b/Bragit/Presentation/Auth/TagCheck/TagCheckViewController.swift
@@ -162,6 +162,25 @@ class TagCheckViewController: UIViewController {
       }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+
+    reactor.state.compactMap { $0.errorMessage }
+      .observe(on: MainScheduler.instance)
+      .bind { [weak self] message in
+        let alert = UIAlertController(title: "오류", message: message, preferredStyle: .alert)
+        alert.addAction(.init(title: "확인", style: .default))
+        self?.present(alert, animated: true)
+      }
+      .disposed(by: disposeBag)
+
+    reactor.state.map { $0.isLoading }
+      .distinctUntilChanged()
+      .observe(on: MainScheduler.instance)
+      .bind { [weak self] isLoading in
+        self?.view.isUserInteractionEnabled = !isLoading
+        self?.nextButton.isEnabled = !isLoading
+        self?.beLaterButton.isEnabled = !isLoading
+      }
+      .disposed(by: disposeBag)
   }
 
   private func debugPrintFavoriteTagsFromUserDefaults() {

--- a/Bragit/Presentation/Auth/TagCheck/TagCheckViewController.swift
+++ b/Bragit/Presentation/Auth/TagCheck/TagCheckViewController.swift
@@ -172,14 +172,55 @@ class TagCheckViewController: UIViewController {
       }
       .disposed(by: disposeBag)
 
-    reactor.state.map { $0.isLoading }
+    // isLoading 스트림
+    let loading = reactor.state
+      .map { $0.isLoading }
       .distinctUntilChanged()
-      .observe(on: MainScheduler.instance)
+      .share(replay: 1)
+
+    // 토글마다 업데이트
+    let selectionChanged = Observable.merge(
+      tagCollectionView.rx.itemSelected.map { _ in () },
+      tagCollectionView.rx.itemDeselected.map { _ in () }
+    )
+    .startWith(())
+    .share(replay: 1)
+
+    let hasSelection = selectionChanged
+      .map { [weak self] in
+        guard let self else { return false }
+        let isEmpty = self.tagCollectionView.indexPathsForSelectedItems?.isEmpty ?? true
+        return !isEmpty
+      }
+      .distinctUntilChanged()
+      .share(replay: 1)
+
+    loading
       .bind { [weak self] isLoading in
         self?.view.isUserInteractionEnabled = !isLoading
-        self?.nextButton.isEnabled = !isLoading
-        self?.beLaterButton.isEnabled = !isLoading
       }
+      .disposed(by: disposeBag)
+
+    // 선택된 게 있을 때 nextButton 활성, 로딩 중엔 비활성
+    Observable.combineLatest(hasSelection, loading)
+      .map { has, isLoading in has && !isLoading }
+      .bind(to: nextButton.rx.isEnabled)
+      .disposed(by: disposeBag)
+
+    Observable.combineLatest(hasSelection, loading)
+      .map { has, isLoading in (has && !isLoading) ? 1.0 : 0.5 }
+      .bind { [weak self] alpha in self?.nextButton.alpha = alpha }
+      .disposed(by: disposeBag)
+
+    // 선택된 게 없을 때 beLaterButton 활성, 로딩 중엔 비활성
+    Observable.combineLatest(hasSelection, loading)
+      .map { has, isLoading in !has && !isLoading }
+      .bind(to: beLaterButton.rx.isEnabled)
+      .disposed(by: disposeBag)
+
+    Observable.combineLatest(hasSelection, loading)
+      .map { has, isLoading in (!has && !isLoading) ? 1.0 : 0.5 }
+      .bind { [weak self] alpha in self?.beLaterButton.alpha = alpha }
       .disposed(by: disposeBag)
   }
 
@@ -206,12 +247,22 @@ class TagCheckViewController: UIViewController {
             }
             self.tagCollectionView.reloadData()
           }
+          self.applyButtonStateAccordingToSelection()
         },
         onError: { error in
           print("[ERROR] 태그 로딩 에러: \(error)")
         }
       )
       .disposed(by: disposeBag)
+  }
+
+  private func applyButtonStateAccordingToSelection() {
+    let hasSelection = (tagCollectionView.indexPathsForSelectedItems?.isEmpty == false)
+    let isLoading = reactor?.currentState.isLoading ?? false
+    nextButton.isEnabled = hasSelection && !isLoading
+    nextButton.alpha = nextButton.isEnabled ? 1.0 : 0.5
+    beLaterButton.isEnabled = !hasSelection && !isLoading
+    beLaterButton.alpha = beLaterButton.isEnabled ? 1.0 : 0.5
   }
 
   private func printFavoriteTags(from collectionView: UICollectionView) {

--- a/Bragit/Presentation/Auth/TagCheck/TagCheckViewController.swift
+++ b/Bragit/Presentation/Auth/TagCheck/TagCheckViewController.swift
@@ -5,12 +5,13 @@
 //  Created by luca on 8/27/25.
 //
 
+import UIKit
+
 import Dependencies
 import RxCocoa
 import RxSwift
 import SnapKit
 import Then
-import UIKit
 
 typealias PopularTag = Tag
 

--- a/Bragit/Presentation/Comment/CommentReactor.swift
+++ b/Bragit/Presentation/Comment/CommentReactor.swift
@@ -5,8 +5,9 @@
 //  Created by luca on 9/4/25.
 //
 
-import Dependencies
 import Foundation
+
+import Dependencies
 import ReactorKit
 import RxFlow
 import RxRelay

--- a/Bragit/Presentation/Comment/CommentViewController.swift
+++ b/Bragit/Presentation/Comment/CommentViewController.swift
@@ -47,6 +47,9 @@ final class CommentViewController: UIViewController, View {
     $0.backgroundColor = .systemBackground
     $0.contentInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
     $0.keyboardDismissMode = .interactive
+    $0.separatorStyle = .singleLine
+    $0.separatorColor = .grayScale100
+    $0.separatorInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
   }
 
   private let refreshControl = UIRefreshControl()

--- a/Bragit/Presentation/Comment/CommentViewController.swift
+++ b/Bragit/Presentation/Comment/CommentViewController.swift
@@ -290,7 +290,7 @@ final class CommentViewController: UIViewController, View {
     // 댓글 목록 바인딩
     reactor.state
       .map { $0.comments.sorted { $0.date > $1.date } }
-      .distinctUntilChanged()
+      // .distinctUntilChanged() // 동일 데이터라도 새로고침 시 셀 재구성을 위해 제거
       .observe(on: MainScheduler.instance)
       .bind(
         to: tableView.rx.items(
@@ -372,6 +372,8 @@ final class CommentViewController: UIViewController, View {
           if owner.refreshControl.isRefreshing {
             owner.refreshControl.endRefreshing()
           }
+          // 새로고침 후 상대 시간 재계산을 위해 강제 리로드
+          owner.tableView.reloadData()
         }
         owner.view.isUserInteractionEnabled = !loading
       }
@@ -396,7 +398,8 @@ final class CommentViewController: UIViewController, View {
       .subscribe { [weak self] _ in
         self?.commentTextView.text = ""
         if let tableView = self?.tableView,
-          tableView.numberOfRows(inSection: 0) > 0 {
+          tableView.numberOfRows(inSection: 0) > 0
+        {
           tableView.scrollToRow(
             at: IndexPath(row: 0, section: 0),
             at: .top,
@@ -503,16 +506,17 @@ final class CommentCell: UITableViewCell {
     }
   }
 
-  func configure(nickname: String, profileURLString: String?, date: Date, content: String) {
+  func configure(
+    nickname: String,
+    profileURLString: String?,
+    date: Date,
+    content: String
+  ) {
     nameLabel.text = nickname
     nameLabel.font = UIFont.pretendard(size: 15, weight: .medium)
     nameLabel.textColor = .black
 
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "ko_KR")
-    formatter.timeZone = .current
-    formatter.dateFormat = "yyyy.MM.dd"
-    dateLabel.text = formatter.string(from: date)
+    dateLabel.text = date.timeAgoDisplay()
     dateLabel.font = UIFont.pretendard(size: 13, weight: .regular)
     dateLabel.textColor = .grayScale400
 

--- a/Bragit/Presentation/Comment/CommentViewController.swift
+++ b/Bragit/Presentation/Comment/CommentViewController.swift
@@ -5,13 +5,14 @@
 //  Created by luca on 9/4/25.
 //
 
+import UIKit
+
 import Kingfisher
 import ReactorKit
 import RxCocoa
 import RxSwift
 import SnapKit
 import Then
-import UIKit
 
 final class CommentViewController: UIViewController, View {
   typealias Reactor = CommentReactor

--- a/Bragit/Presentation/Comment/CommentViewController.swift
+++ b/Bragit/Presentation/Comment/CommentViewController.swift
@@ -241,9 +241,13 @@ final class CommentViewController: UIViewController, View {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
 
-    // 당겨서 새로고침
-    refreshControl.rx.controlEvent(.valueChanged)
-      .map { Reactor.Action.refresh }
+    // 당겨서 새로고침: 손을 뗐을 때만 트리거
+    tableView.rx.didEndDragging
+      .filter { [weak self] _ in
+        // 사용자가 드래그를 끝냈고, 임계치를 넘어 refreshControl이 활성화된 경우에만
+        self?.refreshControl.isRefreshing == true
+      }
+      .map { _ in Reactor.Action.refresh }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
 
@@ -398,8 +402,7 @@ final class CommentViewController: UIViewController, View {
       .subscribe { [weak self] _ in
         self?.commentTextView.text = ""
         if let tableView = self?.tableView,
-          tableView.numberOfRows(inSection: 0) > 0
-        {
+          tableView.numberOfRows(inSection: 0) > 0 {
           tableView.scrollToRow(
             at: IndexPath(row: 0, section: 0),
             at: .top,


### PR DESCRIPTION
## 🔗 관련 이슈

close #86 

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 후 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- Apple 가입일 때 mailTextField에 가입 이메일 대신 'Apple Social Account' 삽입<br> 
![Simulator Screen Recording - iPhone 16e - 2025-09-10 at 01 00 37](https://github.com/user-attachments/assets/340a329b-8b25-4e47-9735-e47864ec2f9f)

- 닉네임 중복 체크<br>
![Simulator Screen Recording - iPhone 16e - 2025-09-10 at 01 02 13](https://github.com/user-attachments/assets/102e2a16-0537-4717-9624-fee654f98c2d)


- 건너뛰기 버튼에 존재 의의 심어줌(사진/태그 선택 없어도 다음 버튼으로 단계 넘어감 > 사진/태그 선택 없으면 다음 버튼 비활성, 건너뛰기 버튼 활성화)<br>
![Simulator Screen Recording - iPhone 16e - 2025-09-10 at 01 04 58](https://github.com/user-attachments/assets/c4291a76-319b-481f-a284-73bd5ddd4df3)

- 댓글 날짜 표기법 변경(2025.09.09 > 4초 전)
- 당겨서 새로고침의 작동 시점 변경(당김 임계점에서 업데이트 > 임계점 후 떼면 업데이트)
- 댓글 사이 구분선 추가
![Simulator Screen Recording - iPhone 16e - 2025-09-10 at 01 22 12](https://github.com/user-attachments/assets/7eea27f8-0b56-4de6-8aee-99e45aa1e423)


## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.

- 이메일은.... 잠시 보류다
