### PR TITLE
✨ Feat : #145 마이페이지 하위(팔로잉, 팔로워, 관심태그)에서 이동 로직 구현

### DIFF
--- a/Bragit/Presentation/MyPage/MyPageSub/FavoriteTagsReactor.swift
+++ b/Bragit/Presentation/MyPage/MyPageSub/FavoriteTagsReactor.swift
@@ -21,6 +21,7 @@ class FavoriteTagsReactor: Reactor, Stepper {
   enum Action {
     case backButtonTap
     case followButtonTap(Tag)
+    case tagDidTap(Tag)
   }
 
   // 상태변경 이벤트 정의 (상태를 어떻게 바꿀 것인가)
@@ -54,7 +55,9 @@ class FavoriteTagsReactor: Reactor, Stepper {
       } else {
         tags = tags! + [tag]
       }
-
+      return .empty()
+    case .tagDidTap(let tag):
+      steps.accept(AppStep.tagInform(tag))
       return .empty()
     }
   }

--- a/Bragit/Presentation/MyPage/MyPageSub/FavoriteTagsViewController.swift
+++ b/Bragit/Presentation/MyPage/MyPageSub/FavoriteTagsViewController.swift
@@ -47,5 +47,9 @@ class FavoriteTagsViewController: ProfileListViewController<Tag>, View {
       .map { .tagDidTap($0) }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+
+    self.rx.viewWillAppear
+      .bind { _ in self.reload() }
+      .disposed(by: disposeBag)
   }
 }

--- a/Bragit/Presentation/MyPage/MyPageSub/FavoriteTagsViewController.swift
+++ b/Bragit/Presentation/MyPage/MyPageSub/FavoriteTagsViewController.swift
@@ -41,5 +41,11 @@ class FavoriteTagsViewController: ProfileListViewController<Tag>, View {
       .compactMap { $0 }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+
+    profileListView.collectionView.rx.itemSelected
+      .map { self.tags[$0.row] }
+      .map { .tagDidTap($0) }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
   }
 }

--- a/Bragit/Presentation/MyPage/MyPageSub/FollowerReactor.swift
+++ b/Bragit/Presentation/MyPage/MyPageSub/FollowerReactor.swift
@@ -22,6 +22,7 @@ class FollowerReactor: Reactor, Stepper {
   enum Action {
     case backButtonTap
     case followButtonTap(User)
+    case userDidTap(User)
   }
 
   // 상태변경 이벤트 정의 (상태를 어떻게 바꿀 것인가)
@@ -58,6 +59,9 @@ class FollowerReactor: Reactor, Stepper {
           print(error)
         }
       }
+      return .empty()
+    case .userDidTap(let user):
+      steps.accept(AppStep.userProfile(user: user))
       return .empty()
     }
   }

--- a/Bragit/Presentation/MyPage/MyPageSub/FollowerVIewController.swift
+++ b/Bragit/Presentation/MyPage/MyPageSub/FollowerVIewController.swift
@@ -47,5 +47,9 @@ class FollowerViewController: ProfileListViewController<User>, View {
       .map { .userDidTap($0) }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+
+    self.rx.viewWillAppear
+      .bind { _ in self.reload() }
+      .disposed(by: disposeBag)
   }
 }

--- a/Bragit/Presentation/MyPage/MyPageSub/FollowerVIewController.swift
+++ b/Bragit/Presentation/MyPage/MyPageSub/FollowerVIewController.swift
@@ -41,5 +41,11 @@ class FollowerViewController: ProfileListViewController<User>, View {
       .compactMap { $0 }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+
+    profileListView.collectionView.rx.itemSelected
+      .map { self.users[$0.row] }
+      .map { .userDidTap($0) }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
   }
 }

--- a/Bragit/Presentation/MyPage/MyPageSub/FollowingReactor.swift
+++ b/Bragit/Presentation/MyPage/MyPageSub/FollowingReactor.swift
@@ -22,6 +22,7 @@ class FollowingReactor: Reactor, Stepper {
   enum Action {
     case backButtonTap
     case followButtonTap(User)
+    case userDidTap(User)
   }
 
   // 상태변경 이벤트 정의 (상태를 어떻게 바꿀 것인가)
@@ -58,6 +59,9 @@ class FollowingReactor: Reactor, Stepper {
           print(error)
         }
       }
+      return .empty()
+    case .userDidTap(let user):
+      steps.accept(AppStep.userProfile(user: user))
       return .empty()
     }
   }

--- a/Bragit/Presentation/MyPage/MyPageSub/FollowingViewController.swift
+++ b/Bragit/Presentation/MyPage/MyPageSub/FollowingViewController.swift
@@ -41,5 +41,11 @@ class FollowingViewController: ProfileListViewController<User>, View {
       .compactMap { $0 }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+
+    profileListView.collectionView.rx.itemSelected
+      .map { self.users[$0.row] }
+      .map { .userDidTap($0) }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
   }
 }

--- a/Bragit/Presentation/MyPage/MyPageSub/FollowingViewController.swift
+++ b/Bragit/Presentation/MyPage/MyPageSub/FollowingViewController.swift
@@ -47,5 +47,9 @@ class FollowingViewController: ProfileListViewController<User>, View {
       .map { .userDidTap($0) }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
+
+    self.rx.viewWillAppear
+      .bind { _ in self.reload() }
+      .disposed(by: disposeBag)
   }
 }

--- a/Bragit/Presentation/MyPage/MyPageSub/ProfileListViewController.swift
+++ b/Bragit/Presentation/MyPage/MyPageSub/ProfileListViewController.swift
@@ -69,4 +69,8 @@ class ProfileListViewController<H: Hashable>: UIViewController {
       return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: identifier)
     }
   }
+
+  func reload() {
+    profileListView.collectionView.reloadData()
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

close #145 

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 후 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- 마이페이지 하위(팔로잉, 팔로워, 관심태그)에서 이동 로직 구현
- 마이페이지 하위(팔로잉, 팔로워, 관심태그)에서 화면 갱신 구현

