### PR TITLE
🚀 Perf: 고용량 사진을 업로드하면 메모리가 심각하게 많이 사용되어 과부하가 걸리는 문제 해결

### DIFF
--- a/Bragit.xcodeproj/project.pbxproj
+++ b/Bragit.xcodeproj/project.pbxproj
@@ -343,7 +343,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Bragit.Bragit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Bragit.develop;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = bragit.Bragit;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Bragit/Model/PreviewModel.swift
+++ b/Bragit/Model/PreviewModel.swift
@@ -63,20 +63,6 @@ struct TagItem: Hashable {
   var tag: String
 }
 
-enum PostImageType {
-  case thumbnail   // 대표 썸네일
-  case content     // 본문 이미지
-
-  // 리사이즈할 최대 픽셀과 JPEG 압축 품질
-  var config: (maxDimension: CGFloat, quality: CGFloat) {
-    switch self {
-    case .thumbnail:
-      return (maxDimension: 600, quality: 0.7)
-    case .content:
-      return (maxDimension: 1280, quality: 0.8)
-    }
-  }
-}
 
 // 이미지 저장 경로 path
 struct StoragePath {

--- a/Bragit/Presentation/DesignSystem/EditorView.swift
+++ b/Bragit/Presentation/DesignSystem/EditorView.swift
@@ -65,15 +65,18 @@ final class EditorView: UIView {
   }
 
   func insertImage(image: UIImage) {
-    // 이미지 첨부(Attachment) 객체를 생성
-    let attachment = NSTextAttachment()
-    attachment.image = image
+    // 본문 이미지는 1280
+    let maxDimension: CGFloat = 1280
+    let resizedImage = image.resized(in: CGSize(width: maxDimension, height: maxDimension)) ?? image
 
-    // 이미지의 크기를 에디터의 폭에 맞게 조절
+    let attachment = NSTextAttachment()
+    attachment.image = resizedImage
+
+    // 에디터 폭에 맞게 크기 조절
     let screenWidth = self.bounds.width
-    let padding: CGFloat = 16 // 에디터의 좌우 여백을 고려
+    let padding: CGFloat = 16
     let imageWidth = screenWidth - padding
-    let aspectRatio = image.size.height / image.size.width
+    let aspectRatio = resizedImage.size.height / resizedImage.size.width
     let imageHeight = imageWidth * aspectRatio
     attachment.bounds = CGRect(x: 0, y: 0, width: imageWidth, height: imageHeight)
 

--- a/Bragit/Presentation/Write/Preview/PreviewReactor.swift
+++ b/Bragit/Presentation/Write/Preview/PreviewReactor.swift
@@ -112,9 +112,15 @@ class PreviewReactor: Reactor, Stepper {
       print("유저 ID: \(author)")
       print("게시글 ID: \(postId)")
 
-      let representativeImageData = currentState.representativeImage?.compress(for: .thumbnail)
+      //썸네일은 별도 규격 (600px) 리사이즈
+      let representativeImageData: Data? = {
+        guard let image = currentState.representativeImage else { return nil }
+        let resized = image.resized(in: CGSize(width: 600, height: 600)) ?? image
+        return resized.jpegData(compressionQuality: 0.8)
+      }()
+
       let contentImages = PreviewReactor.extractImages(from: currentState.content)
-      let attachmentDataList = contentImages.compactMap { $0.compress(for: .content) }
+      let attachmentDataList = contentImages.compactMap { $0.jpegData(compressionQuality: 0.8) }
 
       print("대표 이미지: \(representativeImageData != nil)")
       print("본문 이미지 개수: \(attachmentDataList.count)")
@@ -186,7 +192,7 @@ class PreviewReactor: Reactor, Stepper {
             return .just(.setError(error))
           }
       ])
-      
+
     case .updateDescription(let text):
       return .just(.setDescription(text))
     }

--- a/Bragit/Presentation/Write/Preview/PreviewViewController.swift
+++ b/Bragit/Presentation/Write/Preview/PreviewViewController.swift
@@ -404,7 +404,7 @@ final class PreviewViewController: UIViewController, View {
     // 요약 셀 설정
     let descRegistration = UICollectionView.CellRegistration<DescriptionCell, Item> { [weak self] cell, _, item in
       guard let self, let reactor = self.reactor,
-            case let .description(descriptionItem) = item else { return }
+      case let .description(descriptionItem) = item else { return }
       cell.configure(text: descriptionItem.text)
 
       cell.descriptionLabel.rx.text.orEmpty
@@ -519,7 +519,12 @@ extension PreviewViewController: PHPickerViewControllerDelegate {
       if provider.canLoadObject(ofClass: UIImage.self) {
         provider.loadObject(ofClass: UIImage.self) { [weak self] object, _ in
           guard let self, let image = object as? UIImage else { return }
-          self.reactor?.action.onNext(.appendThumbnail(image))
+          // 선택 즉시 600px 규격으로 리사이즈
+          let resized = image.resized(in: CGSize(width: 600, height: 600)) ?? image
+
+          DispatchQueue.main.async {
+            self.reactor?.action.onNext(.appendThumbnail(resized))
+          }
         }
       }
     }

--- a/Bragit/Util/UIImage++.swift
+++ b/Bragit/Util/UIImage++.swift
@@ -7,28 +7,13 @@
 import UIKit
 
 extension UIImage {
-  // Post 저장용으로 리사이즈 & 압축 → Data 반환
-  func compress(for type: PostImageType) -> Data? {
-    let (maxDimension, quality) = type.config
-
-    let originalSize = size
-    let longestSide = max(originalSize.width, originalSize.height)
-
-    // 이미 충분히 작으면 리사이즈 생략
-    let scale = longestSide > maxDimension ? (maxDimension / longestSide) : 1.0
-    let targetSize = CGSize(width: originalSize.width * scale, height: originalSize.height * scale)
-
-    // CoreGraphics 기반 리사이즈
-    UIGraphicsBeginImageContextWithOptions(targetSize, false, 1.0) // 배경색 투명설정
-    defer { UIGraphicsEndImageContext() }
-    draw(in: CGRect(origin: .zero, size: targetSize))
-    let resized = UIGraphicsGetImageFromCurrentImageContext()
-
-    // JPEG 압축
-    return resized?.jpegData(compressionQuality: quality)
+  // 특정 크기로 이미지 리사이즈 (비율 유지)
+  func resized(in boundsSize: CGSize) -> UIImage? {
+     let ratio = min(boundsSize.width / size.width, boundsSize.height / size.height)
+     return resized(to: CGSize(width: size.width * ratio, height: size.height * ratio))
   }
 
-  // 특정 크기로 이미지 리사이즈
+  // 특정 크기로 이미지 리사이즈 (강제)
   func resized(to size: CGSize) -> UIImage {
     return UIGraphicsImageRenderer(size: size).image { _ in
       draw(in: CGRect(origin: .zero, size: size))


### PR DESCRIPTION
## 🔗 관련 이슈

close #155 

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 후 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
-  [x] **변경 사항에 대한 테스트를 진행했나요?**

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- 고용량 사진을 업로드하면 메모리가 심각하게 많이 사용되어 과부하가 걸리는 문제가있어서 업로드를 하면 바로 다운샘플링을하여 메모리 사용량을 최적화하여 최대한 메모리가 많이 사용되지 않게 해결 

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.

- 

## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.

- 
